### PR TITLE
Add simple autopilot and fuel tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Simple command line A320 flight simulator for instrument flying. The
 simulator uses the [JSBSim](https://github.com/JSBSim-Team/jsbsim) flight
-dynamics engine and a very small script to maintain altitude, heading and
-speed.  No graphics are provided – the goal is to use external hardware like
-LED displays or buttons for cockpit interaction.
+dynamics engine and now features a tiny autopilot with PID controllers for
+heading, altitude and speed. Engines are started automatically and the
+remaining fuel is displayed as the flight progresses. No graphics are
+provided – the goal is to use external hardware like LED displays or buttons
+for cockpit interaction.
 
 ## Quick start
 
@@ -20,7 +22,7 @@ pip install jsbsim
 python ifrsim.py
 ```
 
-The output prints the simulated altitude, airspeed and heading every
+The output shows altitude, airspeed, heading and remaining fuel every
 few seconds.  The aircraft model definition is stored in `data/A320`.
 
 This is only a minimal starting point for a larger non-graphical IFR

--- a/ifrsim.py
+++ b/ifrsim.py
@@ -1,6 +1,68 @@
 import jsbsim
 import time
 
+
+class PIDController:
+    """Very small PID controller used for the autopilot."""
+
+    def __init__(self, kp, ki=0.0, kd=0.0):
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self.integral = 0.0
+        self.prev_error = 0.0
+
+    def update(self, error, dt):
+        self.integral += error * dt
+        derivative = (error - self.prev_error) / dt if dt > 0 else 0.0
+        self.prev_error = error
+        return self.kp * error + self.ki * self.integral + self.kd * derivative
+
+
+class Autopilot:
+    """Simple heading, altitude and speed hold."""
+
+    def __init__(self, fdm, dt):
+        self.fdm = fdm
+        self.dt = dt
+        self.altitude = 0.0
+        self.heading = 0.0
+        self.speed = 0.0
+        self.vs_pid = PIDController(0.005)
+        self.hdg_pid = PIDController(0.02)
+        self.spd_pid = PIDController(0.01)
+
+    def set_targets(self, altitude=None, heading=None, speed=None):
+        if altitude is not None:
+            self.altitude = altitude
+        if heading is not None:
+            self.heading = heading
+        if speed is not None:
+            self.speed = speed
+
+    def update(self):
+        f = self.fdm
+        alt = f.get_property_value('position/h-sl-ft')
+        psi = f.get_property_value('attitude/psi-deg')
+        speed = f.get_property_value('velocities/vt-fps') / 1.68781
+        vs = f.get_property_value('velocities/h-dot-fps')
+
+        alt_error = self.altitude - alt
+        vs_target = max(min(alt_error * 0.1, 15.0), -15.0)
+        vs_error = vs_target - vs
+        pitch_cmd = max(min(self.vs_pid.update(vs_error, self.dt), 0.3), -0.3)
+        f['fcs/elevator-cmd-norm'] = pitch_cmd
+
+        heading_error = (self.heading - psi + 180) % 360 - 180
+        aileron_cmd = max(min(self.hdg_pid.update(heading_error, self.dt), 0.3), -0.3)
+        f['fcs/aileron-cmd-norm'] = aileron_cmd
+
+        speed_error = self.speed - speed
+        throttle_cmd = max(min(self.spd_pid.update(speed_error, self.dt), 1.0), 0.0)
+        f['fcs/throttle-cmd-norm'] = throttle_cmd
+
+        return alt, speed, psi, pitch_cmd, aileron_cmd, throttle_cmd
+
 class A320IFRSim:
     def __init__(self, root_dir='jsbsim-master', dt=0.02):
         self.fdm = jsbsim.FGFDMExec(None, None)
@@ -11,7 +73,9 @@ class A320IFRSim:
         self.target_altitude = 4000  # feet
         self.target_psi = 0  # heading degrees
         self.target_speed = 250  # knots
+        self.autopilot = Autopilot(self.fdm, dt)
         self.init_conditions()
+        self.autopilot.set_targets(self.target_altitude, self.target_psi, self.target_speed)
 
     def init_conditions(self):
         f = self.fdm
@@ -25,27 +89,12 @@ class A320IFRSim:
         f['ic/lat_gc-deg'] = 37.615
         f['ic/weight-lbs'] = 130000
         f.run_ic()
+        f['propulsion/set-running'] = 1
 
     def step(self):
-        f = self.fdm
-        alt = f.get_property_value('position/h-sl-ft')
-        speed = f.get_property_value('velocities/vt-fps') / 1.68781
-        psi = f.get_property_value('attitude/psi-deg')
-
-        # Simple controllers
-        alt_error = self.target_altitude - alt
-        pitch_cmd = max(min(alt_error * 0.0005, 0.2), -0.2)
-        f['fcs/elevator-cmd-norm'] = pitch_cmd
-
-        heading_error = (self.target_psi - psi + 180) % 360 - 180
-        aileron_cmd = max(min(heading_error * 0.02, 0.3), -0.3)
-        f['fcs/aileron-cmd-norm'] = aileron_cmd
-
-        speed_error = self.target_speed - speed
-        throttle_cmd = max(min(speed_error * 0.01, 1.0), 0)
-        f['fcs/throttle-cmd-norm'] = throttle_cmd
-
-        f.run()
+        alt, speed, psi, pitch_cmd, aileron_cmd, throttle_cmd = self.autopilot.update()
+        fuel = self.fdm.get_property_value('propulsion/total-fuel-lbs')
+        self.fdm.run()
         return {
             'altitude_ft': alt,
             'speed_kt': speed,
@@ -53,13 +102,18 @@ class A320IFRSim:
             'pitch_cmd': pitch_cmd,
             'aileron_cmd': aileron_cmd,
             'throttle_cmd': throttle_cmd,
+            'fuel_lbs': fuel,
         }
 
     def run(self, steps=600):
         for i in range(steps):
             data = self.step()
             if i % 50 == 0:
-                print(f"t={i*self.fdm.get_delta_t():.1f}s alt={data['altitude_ft']:.1f}ft speed={data['speed_kt']:.1f}kt heading={data['heading_deg']:.1f}")
+                print(
+                    f"t={i*self.fdm.get_delta_t():.1f}s alt={data['altitude_ft']:.1f}ft "
+                    f"spd={data['speed_kt']:.1f}kt hdg={data['heading_deg']:.1f} "
+                    f"fuel={data['fuel_lbs']:.0f}lb"
+                )
             time.sleep(self.fdm.get_delta_t())
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add small PID-based autopilot with heading, altitude and speed hold
- engines start automatically and remaining fuel is shown
- README updated with new description and output info

## Testing
- `python ifrsim.py > /tmp/out.txt && tail -n 5 /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_687774ff3fb883219c220cee0c85a422