### PR TITLE
Add basic fuel system and engine data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ dynamics engine and now features a lightweight autopilot with PID controllers
 for heading, altitude and speed.  Basic automatic flap and gear scheduling as
 well as a yaw damper add a little system depth. Engines are started
 automatically and the remaining fuel is displayed as the flight progresses.
+Recent updates include a simple fuel system that reports per-engine fuel flow
+and throttle commands with a short spool lag for more realistic behaviour.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 


### PR DESCRIPTION
## Summary
- simulate throttle lag on both engines
- add fuel system class for tank levels and burn rate
- print N1, fuel flow and throttle in the console output
- document the new realism features in the README

## Testing
- `python ifrsim.py > /tmp/test.log && tail -n 3 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6877977d99448321b145bbbac12e74cc