### PR TITLE
Improve simulator system realism with bleed air model

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ An automatic autothrottle system now maintains the commanded airspeed for
 more realistic power management. The latest build adds an overspeed warning
 with automatic speedbrake deployment and introduces random hydraulic pump
 failures for additional system depth.
+A new bleed air model now ties engine and APU performance to cabin
+pressurization and anti-ice efficiency for greater realism.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 


### PR DESCRIPTION
## Summary
- model bleed air availability using engines and APU
- connect bleed air to pressurization and anti‑ice effectiveness
- expose bleed pressure in telemetry output and README

## Testing
- `python ifrsim.py --help` *(fails: displays startup output then first telemetry lines)*

------
https://chatgpt.com/codex/tasks/task_e_6877b460fdd883219e00ea694ff48634