### PR TITLE
Improve engine startup realism

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ with automatic speedbrake deployment and introduces random hydraulic pump
 failures for additional system depth.
 A new bleed air model now ties engine and APU performance to cabin
 pressurization and anti-ice efficiency for greater realism.
+Engines now start using bleed air from the APU and take a few seconds to
+reach idle for more authentic startup behaviour.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 


### PR DESCRIPTION
## Summary
- add `EngineStartSystem` to simulate bleed-air engine startup
- start APU at initialization and request engine start using this new system
- document new startup realism in README

## Testing
- `python -m py_compile ifrsim.py`
- `python ifrsim.py | grep -m 6 "alt="`

------
https://chatgpt.com/codex/tasks/task_e_6877b64e82f08321bd75fd311fded7fe