### PR TITLE
Add basic waypoint navigation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A new bleed air model now ties engine and APU performance to cabin
 pressurization and anti-ice efficiency for greater realism.
 Engines now start using bleed air from the APU and take a few seconds to
 reach idle for more authentic startup behaviour.
+A small navigation system lets the autopilot track a short series of
+waypoints for basic route following.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 


### PR DESCRIPTION
## Summary
- extend README with navigation mention
- introduce `NavigationSystem` for waypoint tracking
- connect autopilot to follow waypoints
- print distance to waypoint during run

## Testing
- `python ifrsim.py 2>&1 | head -n 20`
- `python - <<'EOF'
from ifrsim import A320IFRSim
sim = A320IFRSim()
for i in range(5):
    data = sim.step()
    print(i, data['nav_dist_nm'])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6877bdaeed9483218308a26167791af5