### PR TITLE
Add oil system with engine integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A small navigation system lets the autopilot track a short series of
 waypoints for basic route following.
 Random generator failures may require the APU to power the aircraft and
 severe icing can now lead to engine flameouts that need a restart.
+An oil system tracks pressure and temperature and may cause engine
+failures when overheating or losing lubrication.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 


### PR DESCRIPTION
## Summary
- implement `OilSystem` to track pressure and temperature
- integrate oil model into `Engine`
- expose oil parameters via `Autopilot` and `A320IFRSim`
- log oil information during simulation
- document the new oil system in README

## Testing
- `pip install jsbsim -q`
- `python ifrsim.py` *(fails: BrokenPipeError after truncated output)*

------
https://chatgpt.com/codex/tasks/task_e_687811026084832188c5c5f4d8a1a1f6