### PR TITLE
Add engine exhaust temperature model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ An oil system tracks pressure and temperature and may cause engine
 failures when overheating or losing lubrication.
 A simple fire detection and suppression system automatically
 extinguishes engine fires using two bottles for added emergency depth.
+An exhaust temperature model now tracks engine heat and can cause
+failures when limits are exceeded for even more realism.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 


### PR DESCRIPTION
## Summary
- track exhaust gas temperature for engines
- fail engine on sustained overheat
- expose EGT through autopilot and display
- document new feature in README

## Testing
- `python ifrsim.py`

------
https://chatgpt.com/codex/tasks/task_e_6878a977e014832198909c4d400ffa1a