### PR TITLE
Add emergency ram air turbine

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ A small navigation system lets the autopilot track a short series of
 waypoints for basic route following.
 Random generator failures may require the APU to power the aircraft and
 severe icing can now lead to engine flameouts that need a restart.
+An emergency ram air turbine automatically deploys when both the generator
+and APU fail, keeping essential systems powered until normal power is
+restored.
 An oil system tracks pressure and temperature and may cause engine
 failures when overheating or losing lubrication.
 A simple fire detection and suppression system automatically


### PR DESCRIPTION
## Summary
- implement a small Ram Air Turbine model that deploys when main power is lost
- integrate RAT with the electrical system and autopilot output
- mention the new feature in the README

## Testing
- `python ifrsim.py`

------
https://chatgpt.com/codex/tasks/task_e_6878ad8636448321901d3aa6c3da1b9a