### PR TITLE
Add simple ILS approach mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ An exhaust temperature model now tracks engine heat and can cause
 failures when limits are exceeded for even more realism.
 A simple vertical navigation mode adjusts climb and descent rates to
 meet waypoint altitude constraints when following a route.
+An approach mode now tracks an ILS localizer and glideslope for hands-off
+landings.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 


### PR DESCRIPTION
## Summary
- add an ILSSystem for localizer/glideslope tracking
- update Autopilot to use the ILS when available
- wire new ILS mode into A320IFRSim and print approach info
- mention ILS capability in README

## Testing
- `python -m py_compile ifrsim.py`
- `python ifrsim.py` (fails: ModuleNotFoundError: No module named 'jsbsim')
- `pip install jsbsim`
- `python ifrsim.py`

------
https://chatgpt.com/codex/tasks/task_e_6878b2382b0c83219604bf6ecd2aefc6