### PR TITLE
Add master caution system

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ A simple fire detection and suppression system automatically
 extinguishes engine fires using two bottles for added emergency depth.
 An exhaust temperature model now tracks engine heat and can cause
 failures when limits are exceeded for even more realism.
+A simple master caution system now highlights active warnings from
+multiple subsystems.
 A simple vertical navigation mode adjusts climb and descent rates to
 meet waypoint altitude constraints when following a route.
 An approach mode now tracks an ILS localizer and glideslope for hands-off


### PR DESCRIPTION
## Summary
- add MasterCautionSystem to aggregate warnings
- expose master caution in A320IFRSim telemetry and log output
- document master caution system in README

## Testing
- `python -m py_compile ifrsim.py`
- `python ifrsim.py > /tmp/run.log && tail -n 1 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_6878de4aba4c8321ac24858a68426bb8