### PR TITLE
Add manual A320 control panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ system depth.
 A basic autobrake system now manages wheel braking after touchdown for
 more realistic landings.
 A small cockpit interface exposes autopilot, radio, transponder,
-autobrake, engine start and APU controls.
+autobrake, engine start and APU controls. Manual gear, flap and
+speedbrake levers are available alongside an option to disable the
+automatic system scheduling.
 A small navigation system lets the autopilot track a short series of
 waypoints for basic route following.
 Random generator failures may require the APU to power the aircraft and

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -212,3 +212,25 @@ class FuelPanel:
     def toggle_crossfeed(self) -> None:
         self.fuel.crossfeed_on = not self.fuel.crossfeed_on
 
+
+class FlightControlPanel:
+    """Manually command gear, flap and speedbrake positions."""
+
+    def __init__(self, systems):
+        self.systems = systems
+
+    def set_gear(self, position: str) -> None:
+        """Set landing gear to 'up' or 'down'."""
+        if position.lower() == "down":
+            self.systems.set_targets(gear=1.0)
+        elif position.lower() == "up":
+            self.systems.set_targets(gear=0.0)
+
+    def set_flap(self, setting: float) -> None:
+        """Set the flap lever between 0.0 and 1.0."""
+        self.systems.set_targets(flap=max(0.0, min(setting, 1.0)))
+
+    def set_speedbrake(self, setting: float) -> None:
+        """Set the speedbrake lever between 0.0 and 1.0."""
+        self.systems.set_targets(speedbrake=max(0.0, min(setting, 1.0)))
+

--- a/cockpit.py
+++ b/cockpit.py
@@ -15,6 +15,7 @@ from a320_systems import (
     APUPanel,
     ElectricalPanel,
     FuelPanel,
+    FlightControlPanel,
 )
 
 
@@ -33,6 +34,7 @@ class A320Cockpit:
         self.apu = APUPanel(self.sim.electrics)
         self.electrics = ElectricalPanel(self.sim.electrics)
         self.fuel = FuelPanel(self.sim.fuel)
+        self.controls = FlightControlPanel(self.sim.systems)
         self.pfd = PrimaryFlightDisplay()
         self.ecam_display = EngineDisplay()
         self.fms = FlightManagementSystem(self.sim.nav)
@@ -77,6 +79,7 @@ class A320Cockpit:
                 "target_vs_fpm": self.sim.autopilot.vs_target_fpm,
                 "autobrake_level": self.sim.autobrake.level,
                 "autobrake_active": data["autobrake_active"],
+                "automation": self.sim.autopilot.auto_manage_systems,
             },
             "hydraulics": {"pressure": data["hyd_press"]},
             "electrical": {
@@ -98,6 +101,11 @@ class A320Cockpit:
                 "altitude_ft": data["cabin_altitude_ft"],
                 "diff_psi": data["cabin_diff_psi"],
                 "temperature_c": data["cabin_temp_c"],
+            },
+            "controls": {
+                "flap": data["flap"],
+                "gear": data["gear"],
+                "speedbrake": self.sim.systems.speedbrake,
             },
             "warnings": {
                 "stall": data["stall_warning"],

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -14,6 +14,10 @@ HELP_TEXT = """Available commands:
   spd VALUE           - set target speed in kt
   vs VALUE            - set target vertical speed in fpm
   xfeed on|off        - enable or disable fuel crossfeed
+  gear up|down        - move the landing gear
+  flap VALUE          - set flaps (0.0-1.0)
+  spbrake VALUE       - set speedbrake (0.0-1.0)
+  auto_sys on|off     - toggle automatic system management
   apu start|stop      - start or stop the APU
   engines start       - start the engines
   quit                - exit the program"""
@@ -107,6 +111,32 @@ def main() -> None:
                 cp.autopilot.set_vs(float(args[0]))
             except ValueError:
                 print("Invalid vertical speed")
+            continue
+        if cmd == "gear" and args:
+            if args[0] in {"up", "down"}:
+                cp.controls.set_gear(args[0])
+            else:
+                print("Usage: gear up|down")
+            continue
+        if cmd == "flap" and args:
+            try:
+                cp.controls.set_flap(float(args[0]))
+            except ValueError:
+                print("Invalid flap setting")
+            continue
+        if cmd == "spbrake" and args:
+            try:
+                cp.controls.set_speedbrake(float(args[0]))
+            except ValueError:
+                print("Invalid speedbrake setting")
+            continue
+        if cmd == "auto_sys" and args:
+            if args[0] == "on":
+                cp.sim.autopilot.set_system_automation(True)
+            elif args[0] == "off":
+                cp.sim.autopilot.set_system_automation(False)
+            else:
+                print("Usage: auto_sys on|off")
             continue
         if cmd == "xfeed" and args:
             if args[0] == "on":

--- a/ifrsim.py
+++ b/ifrsim.py
@@ -1118,6 +1118,7 @@ class Autopilot:
         capture_window=200.0,
         climb_vs_fpm=1500.0,
         descent_vs_fpm=-1500.0,
+        auto_manage_systems=True,
     ):
         self.fdm = fdm
         self.dt = dt
@@ -1148,6 +1149,7 @@ class Autopilot:
         self.capture_window = capture_window
         self.climb_vs_fpm = climb_vs_fpm
         self.descent_vs_fpm = descent_vs_fpm
+        self.auto_manage_systems = auto_manage_systems
 
     def engage(self) -> None:
         """Activate the autopilot."""
@@ -1156,6 +1158,10 @@ class Autopilot:
     def disengage(self) -> None:
         """Deactivate the autopilot and release controls."""
         self.engaged = False
+
+    def set_system_automation(self, enabled: bool) -> None:
+        """Enable or disable automatic gear and flap management."""
+        self.auto_manage_systems = enabled
 
     def set_targets(self, altitude=None, heading=None, speed=None, vs=None):
         if altitude is not None:
@@ -1174,6 +1180,8 @@ class Autopilot:
 
     def _manage_systems(self, alt, speed, on_ground):
         """Very naive flap, gear and speedbrake scheduling."""
+        if not self.auto_manage_systems:
+            return
         # Landing gear
         gear_cmd = 1.0 if alt < 1500 and speed < 180 else 0.0
 


### PR DESCRIPTION
## Summary
- implement `FlightControlPanel` for manual gear, flap and speedbrake commands
- expose the panel from `A320Cockpit` and show control status in `step`
- allow toggling of automatic system management in `Autopilot`
- extend cockpit CLI with new commands for manual controls
- document manual controls in README

## Testing
- `python -m py_compile a320_systems.py cockpit.py cockpit_cli.py ifrsim.py tcas.py`
- `python cockpit_cli.py <<'EOF'
status
gear down
flap 0.5
spbrake 0.2
auto_sys off
step
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6878f4132b7c832197d98bb138fc0bb4