### PR TITLE
Add pressurization and warning panels

### DIFF
--- a/a320_systems.py
+++ b/a320_systems.py
@@ -45,6 +45,41 @@ class EngineDisplay:
 
 
 @dataclass
+class PressurizationDisplay:
+    """Show basic cabin pressurization information."""
+
+    cabin_alt_ft: float = 0.0
+    diff_psi: float = 0.0
+    temperature_c: float = 0.0
+
+    def update(self, data: dict) -> None:
+        self.cabin_alt_ft = data.get("cabin_altitude_ft", 0.0)
+        self.diff_psi = data.get("cabin_diff_psi", 0.0)
+        self.temperature_c = data.get("cabin_temp_c", 0.0)
+
+
+@dataclass
+class WarningPanel:
+    """Aggregate important warning flags."""
+
+    master_caution: bool = False
+    stall: bool = False
+    gpws: bool = False
+    overspeed: bool = False
+    fire: bool = False
+    tcas: bool = False
+
+    def update(self, data: dict) -> None:
+        warnings = data.get("warnings", {})
+        self.master_caution = warnings.get("master_caution", False)
+        self.stall = warnings.get("stall", False)
+        self.gpws = warnings.get("gpws", False)
+        self.overspeed = warnings.get("overspeed", False)
+        self.fire = warnings.get("fire", False)
+        self.tcas = warnings.get("tcas", False)
+
+
+@dataclass
 class FlightManagementSystem:
     """Very small FMS handling a route of waypoints."""
 

--- a/cockpit.py
+++ b/cockpit.py
@@ -7,6 +7,8 @@ from a320_systems import (
     PrimaryFlightDisplay,
     EngineDisplay,
     FlightManagementSystem,
+    PressurizationDisplay,
+    WarningPanel,
     AutopilotPanel,
     RadioPanel,
     Transponder,
@@ -37,6 +39,8 @@ class A320Cockpit:
         self.weather_radar = WeatherRadarPanel(self.sim.weather_radar)
         self.pfd = PrimaryFlightDisplay()
         self.ecam_display = EngineDisplay()
+        self.pressurization = PressurizationDisplay()
+        self.warnings_panel = WarningPanel()
         self.fms = FlightManagementSystem(self.sim.nav)
 
     def step(self):
@@ -45,6 +49,16 @@ class A320Cockpit:
         self.pfd.update(data)
         self.ecam_display.update(data)
         self.weather_radar.update(data)
+        self.pressurization.update(data)
+        warnings = {
+            "stall": data["stall_warning"],
+            "gpws": data["gpws_warning"],
+            "overspeed": data["overspeed_warning"],
+            "fire": data["engine_fire"],
+            "tcas": data["tcas_alert"],
+            "master_caution": data["master_caution"],
+        }
+        self.warnings_panel.update({"warnings": warnings})
         return {
             "pfd": {
                 "altitude_ft": self.pfd.altitude_ft,
@@ -109,14 +123,7 @@ class A320Cockpit:
                 "gear": data["gear"],
                 "speedbrake": self.sim.systems.speedbrake,
             },
-            "warnings": {
-                "stall": data["stall_warning"],
-                "gpws": data["gpws_warning"],
-                "overspeed": data["overspeed_warning"],
-                "fire": data["engine_fire"],
-                "tcas": data["tcas_alert"],
-                "master_caution": data["master_caution"],
-            },
+            "warnings": warnings,
         }
 
 


### PR DESCRIPTION
## Summary
- add `PressurizationDisplay` and `WarningPanel` in `a320_systems`
- expose new panels in `A320Cockpit`
- update cockpit step logic to track pressurization and warnings

## Testing
- `python -m py_compile cockpit.py a320_systems.py ifrsim.py tcas.py cockpit_cli.py`
- `python - <<'PY'
from cockpit import A320Cockpit
cp = A320Cockpit()
status = cp.step()
print(status['cabin'])
print(cp.pressurization.cabin_alt_ft)
print(cp.warnings_panel.master_caution)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6878fa1d1df483219c2d23233e262ba3