### PR TITLE
Add navigation display and status panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ with automatic speedbrake deployment and introduces random hydraulic pump
 failures for additional system depth.
 A simple weather radar now detects heavy precipitation and reports it via
 the cockpit interface.
+A simple navigation display shows distance to the active waypoint and ILS
+deviations, while a small systems page tracks hydraulic, electrical and
+bleed air pressure. An overhead panel monitors the APU and fuel crossfeed
+state.
 A new bleed air model now ties engine and APU performance to cabin
 pressurization and anti-ice efficiency for greater realism.
 Hydraulic pumps now depend on engine or APU power, so losing all sources

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -281,3 +281,47 @@ class WeatherRadarPanel:
 
     def update(self, data: dict) -> None:
         self.detecting = data.get("weather_radar", False)
+
+
+@dataclass
+class NavigationDisplay:
+    """Show navigation and ILS information on the ND."""
+
+    distance_nm: float = 0.0
+    ils_distance_nm: float = 0.0
+    loc_dev_deg: float = 0.0
+    gs_dev_ft: float = 0.0
+    tcas_alert: bool = False
+
+    def update(self, data: dict) -> None:
+        self.distance_nm = data.get("nav_dist_nm", 0.0)
+        self.ils_distance_nm = data.get("ils_dist_nm", 0.0)
+        self.loc_dev_deg = data.get("loc_dev_deg", 0.0)
+        self.gs_dev_ft = data.get("gs_dev_ft", 0.0)
+        self.tcas_alert = data.get("tcas_alert", False)
+
+
+@dataclass
+class SystemsStatusPanel:
+    """Display hydraulic, electrical and bleed air status."""
+
+    hydraulic_pressure: float = 0.0
+    electrical_charge: float = 0.0
+    bleed_pressure: float = 0.0
+
+    def update(self, data: dict) -> None:
+        self.hydraulic_pressure = data.get("hyd_press", 0.0)
+        self.electrical_charge = data.get("elec_charge", 0.0)
+        self.bleed_pressure = data.get("bleed_press", 0.0)
+
+
+@dataclass
+class OverheadPanel:
+    """Monitor high level aircraft system states."""
+
+    apu_running: bool = False
+    crossfeed: bool = False
+
+    def update(self, data: dict) -> None:
+        self.apu_running = data.get("apu_running", False)
+        self.crossfeed = data.get("crossfeed", False)

--- a/cockpit.py
+++ b/cockpit.py
@@ -19,6 +19,9 @@ from a320_systems import (
     FuelPanel,
     FlightControlPanel,
     WeatherRadarPanel,
+    NavigationDisplay,
+    SystemsStatusPanel,
+    OverheadPanel,
 )
 
 
@@ -37,6 +40,9 @@ class A320Cockpit:
         self.fuel = FuelPanel(self.sim.fuel)
         self.controls = FlightControlPanel(self.sim.systems)
         self.weather_radar = WeatherRadarPanel(self.sim.weather_radar)
+        self.nav_display = NavigationDisplay()
+        self.system_status = SystemsStatusPanel()
+        self.overhead = OverheadPanel()
         self.pfd = PrimaryFlightDisplay()
         self.ecam_display = EngineDisplay()
         self.pressurization = PressurizationDisplay()
@@ -49,6 +55,9 @@ class A320Cockpit:
         self.pfd.update(data)
         self.ecam_display.update(data)
         self.weather_radar.update(data)
+        self.nav_display.update(data)
+        self.system_status.update(data)
+        self.overhead.update(data)
         self.pressurization.update(data)
         warnings = {
             "stall": data["stall_warning"],
@@ -96,11 +105,27 @@ class A320Cockpit:
                 "autobrake_active": data["autobrake_active"],
                 "automation": self.sim.autopilot.auto_manage_systems,
             },
+            "nav_display": {
+                "distance_nm": self.nav_display.distance_nm,
+                "ils_distance_nm": self.nav_display.ils_distance_nm,
+                "loc_dev_deg": self.nav_display.loc_dev_deg,
+                "gs_dev_ft": self.nav_display.gs_dev_ft,
+                "tcas": self.nav_display.tcas_alert,
+            },
             "hydraulics": {"pressure": data["hyd_press"]},
             "electrical": {
                 "charge": data["elec_charge"],
                 "apu_running": self.sim.electrics.apu_running,
                 "rat_deployed": data["rat_deployed"],
+            },
+            "systems": {
+                "hydraulic_pressure": self.system_status.hydraulic_pressure,
+                "electrical_charge": self.system_status.electrical_charge,
+                "bleed_pressure": self.system_status.bleed_pressure,
+            },
+            "overhead": {
+                "apu_running": self.overhead.apu_running,
+                "crossfeed": self.overhead.crossfeed,
             },
             "weather_radar": self.weather_radar.detecting,
             "tcas": data["tcas_alert"],


### PR DESCRIPTION
## Summary
- implement new NavigationDisplay, SystemsStatusPanel, and OverheadPanel
- wire new panels into `A320Cockpit`
- document the navigation display and system pages in README

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6878fc995ec88321a92856b500c84fd8