### PR TITLE
Add cabin signs system

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ anti-ice system is active.
 Flap and landing gear mechanisms can now jam when moved above their
 overspeed limits and a small cabin temperature model uses bleed air to
 keep the cabin comfortable.
+Seatbelt and no smoking signs can be toggled from the cockpit interface
+to simulate passenger announcements.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -325,3 +325,17 @@ class OverheadPanel:
     def update(self, data: dict) -> None:
         self.apu_running = data.get("apu_running", False)
         self.crossfeed = data.get("crossfeed", False)
+
+
+@dataclass
+class CabinSignsPanel:
+    """Manage seatbelt and no smoking signs."""
+
+    seatbelt_on: bool = False
+    no_smoking_on: bool = False
+
+    def update(self, data: dict) -> None:
+        if "seatbelt_on" in data:
+            self.seatbelt_on = data["seatbelt_on"]
+        if "no_smoking_on" in data:
+            self.no_smoking_on = data["no_smoking_on"]

--- a/cockpit.py
+++ b/cockpit.py
@@ -22,6 +22,7 @@ from a320_systems import (
     NavigationDisplay,
     SystemsStatusPanel,
     OverheadPanel,
+    CabinSignsPanel,
 )
 
 
@@ -43,11 +44,20 @@ class A320Cockpit:
         self.nav_display = NavigationDisplay()
         self.system_status = SystemsStatusPanel()
         self.overhead = OverheadPanel()
+        self.cabin_signs = CabinSignsPanel()
         self.pfd = PrimaryFlightDisplay()
         self.ecam_display = EngineDisplay()
         self.pressurization = PressurizationDisplay()
         self.warnings_panel = WarningPanel()
         self.fms = FlightManagementSystem(self.sim.nav)
+
+    def set_seatbelt_sign(self, on: bool) -> None:
+        """Toggle the seatbelt sign."""
+        self.cabin_signs.seatbelt_on = on
+
+    def set_no_smoking_sign(self, on: bool) -> None:
+        """Toggle the no smoking sign."""
+        self.cabin_signs.no_smoking_on = on
 
     def step(self):
         """Advance the underlying simulation and return a status snapshot."""
@@ -58,6 +68,7 @@ class A320Cockpit:
         self.nav_display.update(data)
         self.system_status.update(data)
         self.overhead.update(data)
+        self.cabin_signs.update(data)
         self.pressurization.update(data)
         warnings = {
             "stall": data["stall_warning"],
@@ -142,6 +153,10 @@ class A320Cockpit:
                 "altitude_ft": data["cabin_altitude_ft"],
                 "diff_psi": data["cabin_diff_psi"],
                 "temperature_c": data["cabin_temp_c"],
+            },
+            "cabin_signs": {
+                "seatbelt": self.cabin_signs.seatbelt_on,
+                "no_smoking": self.cabin_signs.no_smoking_on,
             },
             "controls": {
                 "flap": data["flap"],

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -20,6 +20,8 @@ HELP_TEXT = """Available commands:
   auto_sys on|off     - toggle automatic system management
   apu start|stop      - start or stop the APU
   engines start       - start the engines
+  seatbelt on|off     - toggle the seatbelt sign
+  nosmoke on|off      - toggle the no smoking sign
   quit                - exit the program"""
 
 
@@ -31,7 +33,9 @@ def print_status(status: dict) -> None:
         f"SPD {pfd['speed_kt']:.1f}KT "
         f"HDG {pfd['heading_deg']:.0f} "
         f"VS {pfd['vs_fpm']:.0f}FPM "
-        f"FUEL {ecam['fuel_lbs']:.0f}LB"
+        f"FUEL {ecam['fuel_lbs']:.0f}LB "
+        f"BELT {'ON' if status['cabin_signs']['seatbelt'] else 'OFF'} "
+        f"SMOKE {'ON' if status['cabin_signs']['no_smoking'] else 'OFF'}"
     )
 
 
@@ -145,6 +149,22 @@ def main() -> None:
                 cp.fuel.disable_crossfeed()
             else:
                 print("Usage: xfeed on|off")
+            continue
+        if cmd == "seatbelt" and args:
+            if args[0] == "on":
+                cp.set_seatbelt_sign(True)
+            elif args[0] == "off":
+                cp.set_seatbelt_sign(False)
+            else:
+                print("Usage: seatbelt on|off")
+            continue
+        if cmd == "nosmoke" and args:
+            if args[0] == "on":
+                cp.set_no_smoking_sign(True)
+            elif args[0] == "off":
+                cp.set_no_smoking_sign(False)
+            else:
+                print("Usage: nosmoke on|off")
             continue
         if cmd == "apu" and args:
             if args[0] == "start":


### PR DESCRIPTION
## Summary
- implement `CabinSignsPanel` to manage seatbelt and no-smoking signs
- expose the signs in `A320Cockpit` and cockpit CLI
- allow toggling seatbelt and no-smoking signs via CLI commands
- document signs in README

## Testing
- `python -m py_compile a320_systems.py cockpit.py cockpit_cli.py ifrsim.py tcas.py`
- `python cockpit_cli.py <<'EOF'
seatbelt on
step
quit
EOF`
- `python - <<'EOF'
from cockpit import A320Cockpit
cp=A320Cockpit()
cp.set_seatbelt_sign(True)
cp.set_no_smoking_sign(True)
status=cp.step()
print(status['cabin_signs'])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6878fe4ea27c83219f5ee8b26c173a23