### PR TITLE
Add TCAS display panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ A simple navigation display shows distance to the active waypoint and ILS
 deviations, while a small systems page tracks hydraulic, electrical and
 bleed air pressure. An overhead panel monitors the APU and fuel crossfeed
 state.
+A simple TCAS display now reports the bearing, distance and altitude
+difference to any conflicting traffic.
 A new bleed air model now ties engine and APU performance to cabin
 pressurization and anti-ice efficiency for greater realism.
 Hydraulic pumps now depend on engine or APU power, so losing all sources

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -302,6 +302,26 @@ class NavigationDisplay:
 
 
 @dataclass
+class TCASDisplay:
+    """Show TCAS traffic alert information."""
+
+    bearing_deg: float = 0.0
+    distance_nm: float = 0.0
+    alt_diff_ft: float = 0.0
+    alert: bool = False
+
+    def update(self, data: dict) -> None:
+        alert = data.get("tcas_alert")
+        if alert:
+            self.bearing_deg = alert.get("bearing_deg", 0.0)
+            self.distance_nm = alert.get("distance_nm", 0.0)
+            self.alt_diff_ft = alert.get("alt_diff_ft", 0.0)
+            self.alert = True
+        else:
+            self.alert = False
+
+
+@dataclass
 class SystemsStatusPanel:
     """Display hydraulic, electrical and bleed air status."""
 
@@ -376,6 +396,7 @@ class CockpitSystems:
     pressurization: PressurizationDisplay = field(default_factory=PressurizationDisplay)
     warnings: WarningPanel = field(default_factory=WarningPanel)
     navigation: NavigationDisplay = field(default_factory=NavigationDisplay)
+    tcas: TCASDisplay = field(default_factory=TCASDisplay)
     systems: SystemsStatusPanel = field(default_factory=SystemsStatusPanel)
     overhead: OverheadPanel = field(default_factory=OverheadPanel)
     cabin: CabinSignsPanel = field(default_factory=CabinSignsPanel)
@@ -388,6 +409,7 @@ class CockpitSystems:
         self.pressurization.update(data)
         self.warnings.update({"warnings": data.get("warnings", {})})
         self.navigation.update(data)
+        self.tcas.update(data)
         self.systems.update(data)
         self.overhead.update(data)
         self.cabin.update(data)

--- a/cockpit.py
+++ b/cockpit.py
@@ -20,6 +20,7 @@ from a320_systems import (
     FlightControlPanel,
     WeatherRadarPanel,
     NavigationDisplay,
+    TCASDisplay,
     SystemsStatusPanel,
     OverheadPanel,
     CabinSignsPanel,
@@ -43,6 +44,7 @@ class A320Cockpit:
         self.controls = FlightControlPanel(self.sim.systems)
         self.weather_radar = WeatherRadarPanel(self.sim.weather_radar)
         self.nav_display = NavigationDisplay()
+        self.tcas_display = TCASDisplay()
         self.system_status = SystemsStatusPanel()
         self.overhead = OverheadPanel()
         self.cabin_signs = CabinSignsPanel()
@@ -88,6 +90,7 @@ class A320Cockpit:
         self.ecam_display.update(data)
         self.weather_radar.update(data)
         self.nav_display.update(data)
+        self.tcas_display.update(data)
         self.system_status.update(data)
         self.overhead.update(data)
         self.cabin_signs.update(data)
@@ -161,7 +164,12 @@ class A320Cockpit:
                 "crossfeed": self.overhead.crossfeed,
             },
             "weather_radar": self.weather_radar.detecting,
-            "tcas": data["tcas_alert"],
+            "tcas_display": {
+                "alert": self.tcas_display.alert,
+                "bearing_deg": self.tcas_display.bearing_deg,
+                "distance_nm": self.tcas_display.distance_nm,
+                "alt_diff_ft": self.tcas_display.alt_diff_ft,
+            },
             "navigation": {
                 "active_waypoint": self.fms.active_waypoint(),
             },

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -33,7 +33,7 @@ HELP_TEXT = """Available commands:
 def print_status(status: dict) -> None:
     pfd = status["pfd"]
     ecam = status["ecam"]
-    print(
+    line = (
         f"ALT {pfd['altitude_ft']:.0f}FT "
         f"SPD {pfd['speed_kt']:.1f}KT "
         f"HDG {pfd['heading_deg']:.0f} "
@@ -42,6 +42,14 @@ def print_status(status: dict) -> None:
         f"BELT {'ON' if status['cabin_signs']['seatbelt'] else 'OFF'} "
         f"SMOKE {'ON' if status['cabin_signs']['no_smoking'] else 'OFF'}"
     )
+    tcas = status.get("tcas_display", {})
+    if tcas.get("alert"):
+        line += (
+            f" TCAS {tcas['bearing_deg']:.0f}deg"
+            f" {tcas['distance_nm']:.1f}NM"
+            f" {tcas['alt_diff_ft']:.0f}FT"
+        )
+    print(line)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add a TCASDisplay dataclass to model simple TCAS alerts
- expose the TCAS display via the CockpitSystems helper and A320Cockpit
- show TCAS info in the CLI status output
- document the new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python cockpit_cli.py <<'EOF'
step
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6879064e833c8321a5cca3cfe4b3f19b