### PR TITLE
Add cockpit systems aggregator with autopilot info

### DIFF
--- a/a320_systems.py
+++ b/a320_systems.py
@@ -143,6 +143,32 @@ class AutopilotPanel:
         self.ap.set_targets(vs=vs_fpm)
 
 
+@dataclass
+class AutopilotDisplay:
+    """Show current autopilot and autobrake status."""
+
+    engaged: bool = False
+    autothrottle: bool = False
+    target_altitude_ft: float = 0.0
+    target_heading_deg: float = 0.0
+    target_speed_kt: float = 0.0
+    target_vs_fpm: float = 0.0
+    autobrake_level: str = "off"
+    autobrake_active: bool = False
+    automation: bool = False
+
+    def update(self, data: dict) -> None:
+        self.engaged = data.get("engaged", False)
+        self.autothrottle = data.get("autothrottle", False)
+        self.target_altitude_ft = data.get("target_altitude_ft", 0.0)
+        self.target_heading_deg = data.get("target_heading_deg", 0.0)
+        self.target_speed_kt = data.get("target_speed_kt", 0.0)
+        self.target_vs_fpm = data.get("target_vs_fpm", 0.0)
+        self.autobrake_level = data.get("autobrake_level", "off")
+        self.autobrake_active = data.get("autobrake_active", False)
+        self.automation = data.get("automation", False)
+
+
 class RadioPanel:
     """Very small radio management panel."""
 
@@ -397,6 +423,7 @@ class CockpitSystems:
     warnings: WarningPanel = field(default_factory=WarningPanel)
     navigation: NavigationDisplay = field(default_factory=NavigationDisplay)
     tcas: TCASDisplay = field(default_factory=TCASDisplay)
+    autopilot: AutopilotDisplay = field(default_factory=AutopilotDisplay)
     systems: SystemsStatusPanel = field(default_factory=SystemsStatusPanel)
     overhead: OverheadPanel = field(default_factory=OverheadPanel)
     cabin: CabinSignsPanel = field(default_factory=CabinSignsPanel)
@@ -410,6 +437,7 @@ class CockpitSystems:
         self.warnings.update({"warnings": data.get("warnings", {})})
         self.navigation.update(data)
         self.tcas.update(data)
+        self.autopilot.update(data.get("autopilot", {}))
         self.systems.update(data)
         self.overhead.update(data)
         self.cabin.update(data)

--- a/cockpit.py
+++ b/cockpit.py
@@ -25,6 +25,7 @@ from a320_systems import (
     OverheadPanel,
     CabinSignsPanel,
     LightingPanel,
+    CockpitSystems,
 )
 
 
@@ -54,6 +55,7 @@ class A320Cockpit:
         self.pressurization = PressurizationDisplay()
         self.warnings_panel = WarningPanel()
         self.fms = FlightManagementSystem(self.sim.nav)
+        self.cockpit_systems = CockpitSystems()
 
     def set_seatbelt_sign(self, on: bool) -> None:
         """Toggle the seatbelt sign."""
@@ -104,6 +106,24 @@ class A320Cockpit:
             "master_caution": data["master_caution"],
         }
         self.warnings_panel.update({"warnings": warnings})
+        autopilot_info = {
+            "engaged": self.sim.autopilot.engaged,
+            "autothrottle": self.sim.autopilot.autothrottle.engaged,
+            "target_altitude_ft": self.sim.autopilot.altitude,
+            "target_heading_deg": self.sim.autopilot.heading,
+            "target_speed_kt": self.sim.autopilot.speed,
+            "target_vs_fpm": self.sim.autopilot.vs_target_fpm,
+            "autobrake_level": self.sim.autobrake.level,
+            "autobrake_active": data["autobrake_active"],
+            "automation": self.sim.autopilot.auto_manage_systems,
+        }
+        cockpit_data = {
+            **data,
+            "warnings": warnings,
+            "apu_running": self.sim.electrics.apu_running,
+            "autopilot": autopilot_info,
+        }
+        self.cockpit_systems.update(cockpit_data)
         return {
             "pfd": {
                 "altitude_ft": self.pfd.altitude_ft,
@@ -130,17 +150,7 @@ class A320Cockpit:
                 "code": self.transponder.code,
                 "mode": self.transponder.mode,
             },
-            "autopilot": {
-                "engaged": self.sim.autopilot.engaged,
-                "autothrottle": self.sim.autopilot.autothrottle.engaged,
-                "target_altitude_ft": self.sim.autopilot.altitude,
-                "target_heading_deg": self.sim.autopilot.heading,
-                "target_speed_kt": self.sim.autopilot.speed,
-                "target_vs_fpm": self.sim.autopilot.vs_target_fpm,
-                "autobrake_level": self.sim.autobrake.level,
-                "autobrake_active": data["autobrake_active"],
-                "automation": self.sim.autopilot.auto_manage_systems,
-            },
+            "autopilot": autopilot_info,
             "nav_display": {
                 "distance_nm": self.nav_display.distance_nm,
                 "ils_distance_nm": self.nav_display.ils_distance_nm,


### PR DESCRIPTION
## Summary
- expose autopilot status via new `AutopilotDisplay`
- expand `CockpitSystems` to include autopilot data
- update `A320Cockpit` to populate `CockpitSystems`

## Testing
- `python -m py_compile cockpit.py a320_systems.py cockpit_cli.py ifrsim.py tcas.py`
- `python - <<'PY'
import cockpit
cp = cockpit.A320Cockpit()
print(cp.step()['pfd'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6879083272b88321b2c316587ca5674e