### PR TITLE
Add flight director values to PFD

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Exterior lights such as landing, taxi and strobe lights can be
 controlled via the CLI for basic lighting management.
 The new `CockpitSystems` helper class aggregates all panels so they can be
 updated from a single simulation data snapshot.
+The primary flight display now exposes simple flight director pitch and roll
+commands from the autopilot for external indicators.
 No graphics are provided – the goal is to use external hardware like LED
 displays or buttons for cockpit interaction.
 

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -14,12 +14,16 @@ class PrimaryFlightDisplay:
     speed_kt: float = 0.0
     heading_deg: float = 0.0
     vs_fpm: float = 0.0
+    fd_pitch: float = 0.0
+    fd_roll: float = 0.0
 
     def update(self, data: dict) -> None:
         self.altitude_ft = data.get("altitude_ft", 0.0)
         self.speed_kt = data.get("speed_kt", 0.0)
         self.heading_deg = data.get("heading_deg", 0.0)
         self.vs_fpm = data.get("vs_fpm", 0.0)
+        self.fd_pitch = data.get("pitch_cmd", 0.0)
+        self.fd_roll = data.get("aileron_cmd", 0.0)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- extend `PrimaryFlightDisplay` with flight director pitch and roll
- mention the new flight director data in README

## Testing
- `python -m py_compile *.py`
- `python ifrsim.py > /tmp/sim.log && tail -n 2 /tmp/sim.log`

------
https://chatgpt.com/codex/tasks/task_e_6879586da2888321891b75c4234a3b82