### PR TITLE
Add cockpit clock feature

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -70,6 +70,9 @@ Tracks the seatbelt and no smoking signs.
 ## Oxygen Panel
 Shows the remaining oxygen supply for reference.
 
+## Clock Panel
+Displays the elapsed simulation time.
+
 ## Lighting Panel
 Controls exterior lighting such as landing, taxi, navigation, strobe and beacon
 lights.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Exterior lights such as landing, taxi and strobe lights can be
 controlled via the CLI for basic lighting management.
 An oxygen panel now displays the remaining supply for reference during
 high-altitude flight.
+A small clock shows the elapsed simulation time for reference.
 The new `CockpitSystems` helper class aggregates all panels so they can be
 updated from a single simulation data snapshot.
 The primary flight display now exposes simple flight director pitch and roll

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -428,6 +428,23 @@ class LightingPanel:
 
 
 @dataclass
+class ClockPanel:
+    """Simple chronometer showing elapsed simulation time."""
+
+    time_s: float = 0.0
+
+    def update(self, data: dict) -> None:
+        self.time_s = data.get("time_s", self.time_s)
+
+    @property
+    def time_hms(self) -> str:
+        h = int(self.time_s // 3600)
+        m = int(self.time_s % 3600 // 60)
+        s = int(self.time_s % 60)
+        return f"{h:02}:{m:02}:{s:02}"
+
+
+@dataclass
 class CockpitSystems:
     """Aggregate all major cockpit panels for convenience."""
 
@@ -443,6 +460,7 @@ class CockpitSystems:
     oxygen: 'OxygenPanel' = field(default_factory=lambda: OxygenPanel())
     cabin: CabinSignsPanel = field(default_factory=CabinSignsPanel)
     lights: LightingPanel = field(default_factory=LightingPanel)
+    clock: ClockPanel = field(default_factory=ClockPanel)
 
     def update(self, data: dict) -> None:
         """Update all panels from a simulation snapshot."""
@@ -457,5 +475,6 @@ class CockpitSystems:
         self.overhead.update(data)
         self.oxygen.update(data)
         self.cabin.update(data)
+        self.clock.update(data)
         # Light states are stored in the panel itself, so no update needed
 

--- a/cockpit.py
+++ b/cockpit.py
@@ -26,6 +26,7 @@ from a320_systems import (
     CabinSignsPanel,
     OxygenPanel,
     LightingPanel,
+    ClockPanel,
     CockpitSystems,
 )
 
@@ -52,6 +53,7 @@ class A320Cockpit:
         self.cabin_signs = CabinSignsPanel()
         self.oxygen_display = OxygenPanel()
         self.lights = LightingPanel()
+        self.clock = ClockPanel()
         self.pfd = PrimaryFlightDisplay()
         self.ecam_display = EngineDisplay()
         self.pressurization = PressurizationDisplay()
@@ -100,6 +102,7 @@ class A320Cockpit:
         self.cabin_signs.update(data)
         self.oxygen_display.update(data)
         self.pressurization.update(data)
+        self.clock.update(data)
         warnings = {
             "stall": data["stall_warning"],
             "gpws": data["gpws_warning"],
@@ -214,6 +217,7 @@ class A320Cockpit:
                 "gear": data["gear"],
                 "speedbrake": self.sim.systems.speedbrake,
             },
+            "clock": {"time": self.clock.time_hms},
             "warnings": warnings,
         }
 

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -42,6 +42,7 @@ def print_status(status: dict) -> None:
         f"BELT {'ON' if status['cabin_signs']['seatbelt'] else 'OFF'} "
         f"SMOKE {'ON' if status['cabin_signs']['no_smoking'] else 'OFF'}"
         f" OXY {status['oxygen']['level']:.2f}"
+        f" TIME {status['clock']['time']}"
     )
     tcas = status.get("tcas_display", {})
     if tcas.get("alert"):

--- a/ifrsim.py
+++ b/ifrsim.py
@@ -1403,6 +1403,7 @@ class A320IFRSim:
         self.target_altitude = 4000  # feet
         self.target_psi = 0  # heading degrees
         self.target_speed = 250  # knots
+        self.time_s = 0.0
         self.engines = EngineSystem(
             [
                 Engine(self.fdm, 0, failure_chance=5e-5, fire_chance=1e-5),
@@ -1481,6 +1482,7 @@ class A320IFRSim:
 
     def step(self):
         dt = self.fdm.get_delta_t()
+        self.time_s += dt
         self.environment.update(dt)
         self.starter.update(dt)
         if (
@@ -1591,6 +1593,7 @@ class A320IFRSim:
             "gear_operable": self.systems.gear_operable,
             "tcas_alert": tcas_alert,
             "master_caution": caution,
+            "time_s": self.time_s,
         }
 
     def run(self, steps=600):


### PR DESCRIPTION
## Summary
- add `ClockPanel` to track simulation time
- show elapsed time in cockpit CLI
- expose time in `A320IFRSim` data and propagate through `A320Cockpit`
- document new clock panel

## Testing
- `python -m py_compile a320_systems.py cockpit.py cockpit_cli.py ifrsim.py tcas.py`
- `python - <<'EOF'
from cockpit_cli import print_status, A320Cockpit
cp = A320Cockpit()
status = cp.step()
print_status(status)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68796492a12c83218798e1a4ad36038d