### PR TITLE
Add parking brake system

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -67,6 +67,9 @@ Indicates APU running state and fuel crossfeed status.
 ## Cabin Signs Panel
 Tracks the seatbelt and no smoking signs.
 
+## Parking Brake Panel
+Indicates whether the parking brake is engaged.
+
 ## Oxygen Panel
 Shows the remaining oxygen supply for reference.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ A small brake model tracks heat build-up on the ground for a touch more
 system depth.
 A basic autobrake system now manages wheel braking after touchdown for
 more realistic landings.
+A parking brake can be set via the CLI to hold the aircraft in place on
+the ground.
 A small cockpit interface exposes autopilot, radio, transponder,
 autobrake, engine start and APU controls. Manual gear, flap and
 speedbrake levers are available alongside an option to disable the

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -402,6 +402,17 @@ class CabinSignsPanel:
 
 
 @dataclass
+class ParkingBrakePanel:
+    """Indicate parking brake state."""
+
+    engaged: bool = False
+
+    def update(self, data: dict) -> None:
+        if "parking_brake" in data:
+            self.engaged = data["parking_brake"]
+
+
+@dataclass
 class LightingPanel:
     """Manage exterior light switches."""
 
@@ -460,6 +471,7 @@ class CockpitSystems:
     oxygen: 'OxygenPanel' = field(default_factory=lambda: OxygenPanel())
     cabin: CabinSignsPanel = field(default_factory=CabinSignsPanel)
     lights: LightingPanel = field(default_factory=LightingPanel)
+    parking_brake: ParkingBrakePanel = field(default_factory=ParkingBrakePanel)
     clock: ClockPanel = field(default_factory=ClockPanel)
 
     def update(self, data: dict) -> None:
@@ -475,6 +487,7 @@ class CockpitSystems:
         self.overhead.update(data)
         self.oxygen.update(data)
         self.cabin.update(data)
+        self.parking_brake.update(data)
         self.clock.update(data)
         # Light states are stored in the panel itself, so no update needed
 

--- a/cockpit.py
+++ b/cockpit.py
@@ -26,6 +26,7 @@ from a320_systems import (
     CabinSignsPanel,
     OxygenPanel,
     LightingPanel,
+    ParkingBrakePanel,
     ClockPanel,
     CockpitSystems,
 )
@@ -53,6 +54,7 @@ class A320Cockpit:
         self.cabin_signs = CabinSignsPanel()
         self.oxygen_display = OxygenPanel()
         self.lights = LightingPanel()
+        self.parking_brake = ParkingBrakePanel()
         self.clock = ClockPanel()
         self.pfd = PrimaryFlightDisplay()
         self.ecam_display = EngineDisplay()
@@ -89,6 +91,11 @@ class A320Cockpit:
         """Toggle the beacon light."""
         self.lights.set_beacon(on)
 
+    def set_parking_brake(self, on: bool) -> None:
+        """Engage or release the parking brake."""
+        self.sim.set_parking_brake(on)
+        self.parking_brake.engaged = on
+
     def step(self):
         """Advance the underlying simulation and return a status snapshot."""
         data = self.sim.step()
@@ -100,6 +107,7 @@ class A320Cockpit:
         self.system_status.update(data)
         self.overhead.update(data)
         self.cabin_signs.update(data)
+        self.parking_brake.update(data)
         self.oxygen_display.update(data)
         self.pressurization.update(data)
         self.clock.update(data)
@@ -128,6 +136,7 @@ class A320Cockpit:
             "warnings": warnings,
             "apu_running": self.sim.electrics.apu_running,
             "autopilot": autopilot_info,
+            "parking_brake": self.sim.brakes.parking_brake,
         }
         self.cockpit_systems.update(cockpit_data)
         return {
@@ -216,6 +225,7 @@ class A320Cockpit:
                 "flap": data["flap"],
                 "gear": data["gear"],
                 "speedbrake": self.sim.systems.speedbrake,
+                "parking_brake": self.sim.brakes.parking_brake,
             },
             "clock": {"time": self.clock.time_hms},
             "warnings": warnings,

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -27,6 +27,7 @@ HELP_TEXT = """Available commands:
   navlight on|off     - toggle the navigation lights
   strobelight on|off  - toggle the strobe light
   beacon on|off       - toggle the beacon light
+  pbrake on|off       - set the parking brake
   quit                - exit the program"""
 
 
@@ -43,6 +44,7 @@ def print_status(status: dict) -> None:
         f"SMOKE {'ON' if status['cabin_signs']['no_smoking'] else 'OFF'}"
         f" OXY {status['oxygen']['level']:.2f}"
         f" TIME {status['clock']['time']}"
+        f" PBRK {'ON' if status['controls']['parking_brake'] else 'OFF'}"
     )
     tcas = status.get("tcas_display", {})
     if tcas.get("alert"):
@@ -220,6 +222,14 @@ def main() -> None:
                 cp.set_beacon_light(False)
             else:
                 print("Usage: beacon on|off")
+            continue
+        if cmd == "pbrake" and args:
+            if args[0] == "on":
+                cp.set_parking_brake(True)
+            elif args[0] == "off":
+                cp.set_parking_brake(False)
+            else:
+                print("Usage: pbrake on|off")
             continue
         if cmd == "apu" and args:
             if args[0] == "start":


### PR DESCRIPTION
## Summary
- model parking brake in `BrakeSystem`
- expose `set_parking_brake` via `A320IFRSim`
- add `ParkingBrakePanel` and integrate with `CockpitSystems`
- support parking brake controls in `A320Cockpit` and CLI
- document parking brake feature

## Testing
- `python -m compileall -q .`
- `python ifrsim.py` *(fails: Broken pipe when piped to head)*

------
https://chatgpt.com/codex/tasks/task_e_6879674527c08321863643640d98cd6f