### PR TITLE
Add cockpit systems snapshot example

### DIFF
--- a/cockpit_snapshot.py
+++ b/cockpit_snapshot.py
@@ -1,0 +1,14 @@
+import json
+from cockpit import A320Cockpit
+
+
+def main(steps: int = 5) -> None:
+    cp = A320Cockpit()
+    for _ in range(steps):
+        cp.step()
+        snapshot = cp.cockpit_systems.snapshot()
+        print(json.dumps(snapshot, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `cockpit_snapshot.py` example to print full cockpit system snapshot

## Testing
- `python cockpit_snapshot.py > /tmp/snapshot.log && head -n 20 /tmp/snapshot.log`

------
https://chatgpt.com/codex/tasks/task_e_6879fdcef5f8832198d679a6479a1ef3