### PR TITLE
Add flight controls display

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -51,6 +51,10 @@ Displays tank quantities and manages fuel crossfeed.
 ## Flight Control Panel
 Manually commands landing gear, flap and speedbrake positions.
 
+## Flight Controls Display
+Reports the current flap, gear and speedbrake positions. It also indicates if
+the flap or gear mechanisms are inoperable due to overspeed damage.
+
 ## Weather Radar Panel
 Indicates heavy precipitation detected ahead of the aircraft.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ controlled via the CLI for basic lighting management.
 An oxygen panel now displays the remaining supply for reference during
 high-altitude flight.
 A small clock shows the elapsed simulation time for reference.
+A flight controls display now reports current gear, flap and speedbrake
+positions.
 The new `CockpitSystems` helper class aggregates all panels so they can be
 updated from a single simulation data snapshot. A new `snapshot()` method now
 returns a dictionary with the state of all panels so external software can

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -457,6 +457,29 @@ class LightingPanel:
 
 
 @dataclass
+class FlightControlsDisplay:
+    """Show current gear, flap and speedbrake state."""
+
+    gear: float = 0.0
+    flap: float = 0.0
+    speedbrake: float = 0.0
+    gear_operable: bool = True
+    flap_operable: bool = True
+
+    def update(self, data: dict) -> None:
+        if "gear" in data:
+            self.gear = data["gear"]
+        if "flap" in data:
+            self.flap = data["flap"]
+        if "speedbrake" in data:
+            self.speedbrake = data["speedbrake"]
+        if "gear_operable" in data:
+            self.gear_operable = data["gear_operable"]
+        if "flap_operable" in data:
+            self.flap_operable = data["flap_operable"]
+
+
+@dataclass
 class ClockPanel:
     """Simple chronometer showing elapsed simulation time."""
 
@@ -491,6 +514,7 @@ class CockpitSystems:
     oxygen: 'OxygenPanel' = field(default_factory=lambda: OxygenPanel())
     cabin: CabinSignsPanel = field(default_factory=CabinSignsPanel)
     lights: LightingPanel = field(default_factory=LightingPanel)
+    controls: FlightControlsDisplay = field(default_factory=FlightControlsDisplay)
     parking_brake: ParkingBrakePanel = field(default_factory=ParkingBrakePanel)
     brakes: BrakesPanel = field(default_factory=BrakesPanel)
     clock: ClockPanel = field(default_factory=ClockPanel)
@@ -505,6 +529,7 @@ class CockpitSystems:
         self.tcas.update(data)
         self.autopilot.update(data.get("autopilot", {}))
         self.systems.update(data)
+        self.controls.update(data)
         self.overhead.update(data)
         self.oxygen.update(data)
         self.cabin.update(data)
@@ -538,6 +563,7 @@ class CockpitSystems:
             "oxygen": asdict(self.oxygen),
             "cabin": asdict(self.cabin),
             "lights": asdict(self.lights),
+            "controls": asdict(self.controls),
             "parking_brake": asdict(self.parking_brake),
             "brakes": asdict(self.brakes),
             "clock": {"time_s": self.clock.time_s, "time_hms": self.clock.time_hms},

--- a/ifrsim.py
+++ b/ifrsim.py
@@ -1569,6 +1569,7 @@ class A320IFRSim:
             "n1": n1_list,
             "flap": flap,
             "gear": gear,
+            "speedbrake": self.systems.speedbrake,
             "hyd_press": pressure,
             "elec_charge": elec,
             "anti_ice_on": anti_ice_on,


### PR DESCRIPTION
## Summary
- add a new `FlightControlsDisplay` dataclass
- include flight controls in `CockpitSystems` and snapshot output
- expose speedbrake state from the simulator
- update cockpit system docs
- document new display in README

## Testing
- `python -m py_compile a320_systems.py cockpit.py cockpit_cli.py cockpit_snapshot.py ifrsim.py tcas.py`

------
https://chatgpt.com/codex/tasks/task_e_687a1571720c8321b9913db2ac499247