### PR TITLE
Add fuel panel tracking

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -46,7 +46,7 @@ Handle engine start requests and APU start/stop commands.
 Monitors battery charge, APU status and RAT deployment.
 
 ## Fuel Panel
-Displays tank quantities and manages fuel crossfeed.
+Displays left, right and total tank quantities and manages fuel crossfeed.
 
 ## Flight Control Panel
 Manually commands landing gear, flap and speedbrake positions.

--- a/cockpit.py
+++ b/cockpit.py
@@ -114,6 +114,7 @@ class A320Cockpit:
         self.overhead.update(data)
         self.hydraulic_panel.update(data)
         self.bleed_air_panel.update(data)
+        self.fuel.update(data)
         self.cabin_signs.update(data)
         self.parking_brake.update(data)
         self.brakes_display.update(data)


### PR DESCRIPTION
## Summary
- add dataclass-based `FuelPanel` to record fuel quantities and crossfeed state
- expose the new `FuelPanel` in `CockpitSystems`
- update `A320Cockpit` step logic to keep the panel in sync
- document fuel panel details

## Testing
- `python -m py_compile a320_systems.py cockpit.py`
- `python cockpit_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_687a24399b3483219681298f5c83ce53