### PR TITLE
Add cockpit systems example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ python ifrsim.py
 python cockpit_cli.py
 ```
 
+4. Run the cockpit system snapshot example:
+```bash
+python a320_cockpit_example.py
+```
+
 The output shows altitude, airspeed, heading and remaining fuel every
 few seconds.  The aircraft model definition is stored in `data/A320`.
 

--- a/a320_cockpit_example.py
+++ b/a320_cockpit_example.py
@@ -1,0 +1,23 @@
+from cockpit import A320Cockpit
+
+
+def main(steps: int = 10) -> None:
+    """Run the A320 cockpit simulation for a few steps and print a snapshot."""
+    cp = A320Cockpit()
+    for _ in range(steps):
+        cp.step()
+        snapshot = cp.cockpit_systems.snapshot()
+        # Print a couple of key values from different panels
+        pfd = snapshot["pfd"]
+        engine = snapshot["engine"]
+        warnings = snapshot["warnings"]
+        print(
+            f"ALT {pfd['altitude_ft']:.0f}FT SPD {pfd['speed_kt']:.1f}KT "
+            f"HDG {pfd['heading_deg']:.0f} VS {pfd['vs_fpm']:.0f}FPM "
+            f"N1 {engine['n1'][0]:.2f}/{engine['n1'][1]:.2f} "
+            f"MC {'ON' if warnings['master_caution'] else 'OFF'}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `a320_cockpit_example.py` demonstrating the cockpit system snapshot
- document the new example in the README

## Testing
- `python -m py_compile a320_cockpit_example.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687a265564c48321810f3601c1fff8de