### PR TITLE
Add altimeter panel

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -88,6 +88,10 @@ Shows current brake temperature and whether the autobrake system is active.
 ## Oxygen Panel
 Shows the remaining oxygen supply for reference.
 
+## Altimeter Panel
+Stores the current barometric setting used by the primary flight
+display.
+
 ## Clock Panel
 Displays the elapsed simulation time.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Exterior lights such as landing, taxi and strobe lights can be
 controlled via the CLI for basic lighting management.
 An oxygen panel now displays the remaining supply for reference during
 high-altitude flight.
+A simple altimeter panel stores the barometric setting so the PFD can
+show the correct altitude reference.
 A small clock shows the elapsed simulation time for reference.
 A flight controls display now reports current gear, flap and speedbrake
 positions.

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -67,6 +67,17 @@ class PressurizationDisplay:
 
 
 @dataclass
+class AltimeterPanel:
+    """Set and display the altimeter pressure setting."""
+
+    pressure_hpa: float = 1013.25
+
+    def update(self, data: dict) -> None:
+        if "pressure_hpa" in data:
+            self.pressure_hpa = data["pressure_hpa"]
+
+
+@dataclass
 class WarningPanel:
     """Aggregate important warning flags."""
 
@@ -575,6 +586,7 @@ class CockpitSystems:
     bleed_air: BleedAirPanel = field(default_factory=BleedAirPanel)
     oxygen: 'OxygenPanel' = field(default_factory=lambda: OxygenPanel())
     cabin: CabinSignsPanel = field(default_factory=CabinSignsPanel)
+    altimeter: AltimeterPanel = field(default_factory=AltimeterPanel)
     fuel: FuelPanel = field(default_factory=FuelPanel)
     lights: LightingPanel = field(default_factory=LightingPanel)
     controls: FlightControlsDisplay = field(default_factory=FlightControlsDisplay)
@@ -597,6 +609,7 @@ class CockpitSystems:
         self.controls.update(data)
         self.overhead.update(data)
         self.fuel.update(data)
+        self.altimeter.update(data)
         self.oxygen.update(data)
         self.cabin.update(data)
         self.parking_brake.update(data)
@@ -629,6 +642,7 @@ class CockpitSystems:
             "hydraulics": asdict(self.hydraulics),
             "bleed_air": asdict(self.bleed_air),
             "fuel": self.fuel.to_dict(),
+            "altimeter": asdict(self.altimeter),
             "oxygen": asdict(self.oxygen),
             "cabin": asdict(self.cabin),
             "lights": asdict(self.lights),

--- a/cockpit.py
+++ b/cockpit.py
@@ -28,6 +28,7 @@ from a320_systems import (
     LightingPanel,
     HydraulicPanel,
     BleedAirPanel,
+    AltimeterPanel,
     ParkingBrakePanel,
     BrakesPanel,
     ClockPanel,
@@ -62,6 +63,7 @@ class A320Cockpit:
         self.parking_brake = ParkingBrakePanel()
         self.brakes_display = BrakesPanel()
         self.clock = ClockPanel()
+        self.altimeter = AltimeterPanel()
         self.pfd = PrimaryFlightDisplay()
         self.ecam_display = EngineDisplay()
         self.pressurization = PressurizationDisplay()
@@ -102,6 +104,10 @@ class A320Cockpit:
         self.sim.set_parking_brake(on)
         self.parking_brake.engaged = on
 
+    def set_altimeter(self, pressure_hpa: float) -> None:
+        """Set the altimeter pressure setting."""
+        self.altimeter.pressure_hpa = pressure_hpa
+
     def step(self):
         """Advance the underlying simulation and return a status snapshot."""
         data = self.sim.step()
@@ -120,6 +126,7 @@ class A320Cockpit:
         self.brakes_display.update(data)
         self.oxygen_display.update(data)
         self.pressurization.update(data)
+        self.altimeter.update({"pressure_hpa": self.altimeter.pressure_hpa})
         self.clock.update(data)
         warnings = {
             "stall": data["stall_warning"],
@@ -147,6 +154,7 @@ class A320Cockpit:
             "apu_running": self.sim.electrics.apu_running,
             "autopilot": autopilot_info,
             "parking_brake": self.sim.brakes.parking_brake,
+            "pressure_hpa": self.altimeter.pressure_hpa,
         }
         self.cockpit_systems.update(cockpit_data)
         return {
@@ -227,6 +235,7 @@ class A320Cockpit:
                 "diff_psi": data["cabin_diff_psi"],
                 "temperature_c": data["cabin_temp_c"],
             },
+            "altimeter": {"pressure_hpa": self.altimeter.pressure_hpa},
             "oxygen": {"level": data["oxygen_level"]},
             "cabin_signs": {
                 "seatbelt": self.cabin_signs.seatbelt_on,

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -13,6 +13,7 @@ HELP_TEXT = """Available commands:
   hdg VALUE           - set target heading in deg
   spd VALUE           - set target speed in kt
   vs VALUE            - set target vertical speed in fpm
+  baro VALUE          - set altimeter pressure in hPa
   xfeed on|off        - enable or disable fuel crossfeed
   gear up|down        - move the landing gear
   flap VALUE          - set flaps (0.0-1.0)
@@ -46,6 +47,7 @@ def print_status(status: dict) -> None:
         f"SMOKE {'ON' if status['cabin_signs']['no_smoking'] else 'OFF'}"
         f" OXY {status['oxygen']['level']:.2f}"
         f" TIME {status['clock']['time']}"
+        f" BARO {status['altimeter']['pressure_hpa']:.1f}hPa"
         f" PBRK {'ON' if status['controls']['parking_brake'] else 'OFF'}"
     )
     tcas = status.get("tcas_display", {})
@@ -134,6 +136,12 @@ def main() -> None:
                 cp.autopilot.set_vs(float(args[0]))
             except ValueError:
                 print("Invalid vertical speed")
+            continue
+        if cmd == "baro" and args:
+            try:
+                cp.set_altimeter(float(args[0]))
+            except ValueError:
+                print("Invalid pressure")
             continue
         if cmd == "gear" and args:
             if args[0] in {"up", "down"}:


### PR DESCRIPTION
## Summary
- implement an `AltimeterPanel` dataclass
- update `CockpitSystems` to include altimeter data
- expose altimeter setting in `A320Cockpit`
- support `baro` command in CLI
- document altimeter panel in README and COCKPIT_SYSTEMS docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python a320_cockpit_example.py | head -n 5` *(fails: BrokenPipe error due to piping but code runs)*
- `python cockpit_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_687ddc9900f083218c8bae05c0853bc8