### PR TITLE
Add autopilot vertical mode display

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -38,7 +38,9 @@ autopilot uses for simple vertical navigation.
 Interfaces with the autopilot and autothrottle. The display shows current
 engagement state, targets and autobrake information.  The autopilot can
 automatically manage gear, flaps and speedbrake as well as track altitude
-constraints provided by the FMS.
+constraints provided by the FMS. It also reports the active vertical mode
+(VS, ALT, VNAV or APP) so external displays can mimic the Airbus flight mode
+annunciations.
 
 ## Radio Panel
 Provides simple COM1/COM2 frequency management.  Active and standby

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ A simple vertical navigation mode adjusts climb and descent rates to
 meet waypoint altitude constraints when following a route.
 An approach mode now tracks an ILS localizer and glideslope for hands-off
 landings.
+The autopilot display now reports the active vertical mode (VS, ALT, VNAV or APP)
+so external hardware can mimic the Airbus flight mode annunciations.
 Wing icing is now simulated and increases stall speed unless the wing
 anti-ice system is active.
 Flap and landing gear mechanisms can now jam when moved above their

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -175,6 +175,7 @@ class AutopilotDisplay:
     autobrake_level: str = "off"
     autobrake_active: bool = False
     automation: bool = False
+    vertical_mode: str = "VS"
 
     def update(self, data: dict) -> None:
         self.engaged = data.get("engaged", False)
@@ -186,6 +187,7 @@ class AutopilotDisplay:
         self.autobrake_level = data.get("autobrake_level", "off")
         self.autobrake_active = data.get("autobrake_active", False)
         self.automation = data.get("automation", False)
+        self.vertical_mode = data.get("vertical_mode", self.vertical_mode)
 
 
 class RadioPanel:

--- a/cockpit.py
+++ b/cockpit.py
@@ -150,6 +150,7 @@ class A320Cockpit:
             "autobrake_level": self.sim.autobrake.level,
             "autobrake_active": data["autobrake_active"],
             "automation": self.sim.autopilot.auto_manage_systems,
+            "vertical_mode": self.sim.autopilot.vertical_mode,
         }
         cockpit_data = {
             **data,


### PR DESCRIPTION
## Summary
- track autopilot vertical mode in ifrsim
- expose vertical mode through autopilot display classes
- show vertical mode in README and cockpit systems docs

## Testing
- `python -m py_compile a320_systems.py cockpit.py ifrsim.py cockpit_cli.py a320_cockpit_example.py tcas.py`


------
https://chatgpt.com/codex/tasks/task_e_687df5e2cc30832198f2791516d4b60b