### PR TITLE
Add autopilot lateral mode display

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -39,8 +39,8 @@ Interfaces with the autopilot and autothrottle. The display shows current
 engagement state, targets and autobrake information.  The autopilot can
 automatically manage gear, flaps and speedbrake as well as track altitude
 constraints provided by the FMS. It also reports the active vertical mode
-(VS, ALT, VNAV or APP) so external displays can mimic the Airbus flight mode
-annunciations.
+(VS, ALT, VNAV or APP) and lateral mode (HDG, NAV or LOC) so external displays
+can mimic the Airbus flight mode annunciations.
 
 ## Radio Panel
 Provides simple COM1/COM2 frequency management.  Active and standby

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ meet waypoint altitude constraints when following a route.
 An approach mode now tracks an ILS localizer and glideslope for hands-off
 landings.
 The autopilot display now reports the active vertical mode (VS, ALT, VNAV or APP)
-so external hardware can mimic the Airbus flight mode annunciations.
+and lateral mode (HDG, NAV or LOC) so external hardware can mimic the Airbus
+flight mode annunciations.
 Wing icing is now simulated and increases stall speed unless the wing
 anti-ice system is active.
 Flap and landing gear mechanisms can now jam when moved above their

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -176,6 +176,7 @@ class AutopilotDisplay:
     autobrake_active: bool = False
     automation: bool = False
     vertical_mode: str = "VS"
+    lateral_mode: str = "HDG"
 
     def update(self, data: dict) -> None:
         self.engaged = data.get("engaged", False)
@@ -188,6 +189,7 @@ class AutopilotDisplay:
         self.autobrake_active = data.get("autobrake_active", False)
         self.automation = data.get("automation", False)
         self.vertical_mode = data.get("vertical_mode", self.vertical_mode)
+        self.lateral_mode = data.get("lateral_mode", self.lateral_mode)
 
 
 class RadioPanel:

--- a/cockpit.py
+++ b/cockpit.py
@@ -151,6 +151,7 @@ class A320Cockpit:
             "autobrake_active": data["autobrake_active"],
             "automation": self.sim.autopilot.auto_manage_systems,
             "vertical_mode": self.sim.autopilot.vertical_mode,
+            "lateral_mode": self.sim.autopilot.lateral_mode,
         }
         cockpit_data = {
             **data,

--- a/ifrsim.py
+++ b/ifrsim.py
@@ -1190,6 +1190,7 @@ class Autopilot:
         self.descent_vs_fpm = descent_vs_fpm
         self.auto_manage_systems = auto_manage_systems
         self.vertical_mode = "VS"
+        self.lateral_mode = "HDG"
 
     def engage(self) -> None:
         """Activate the autopilot."""
@@ -1281,6 +1282,7 @@ class Autopilot:
             speed = f.get_property_value("velocities/vt-fps") / 1.68781
         vs = f.get_property_value("velocities/h-dot-fps")  # ft/s
         vertical_mode = "VS"
+        lateral_mode = "HDG"
 
         loc_dev = None
         gs_dev = None
@@ -1291,6 +1293,7 @@ class Autopilot:
                 self.heading = self.ils.hdg + loc_dev
                 self.altitude = alt - gs_dev
                 vertical_mode = "APP"
+                lateral_mode = "LOC"
             else:
                 vertical_mode = "VS"
         
@@ -1299,6 +1302,7 @@ class Autopilot:
             nav_bearing, nav_dist, nav_alt = self.nav.update()
             if nav_bearing is not None:
                 self.heading = nav_bearing
+                lateral_mode = "NAV"
             if nav_alt is not None:
                 self.altitude = nav_alt
             if (
@@ -1379,6 +1383,7 @@ class Autopilot:
         oil_p = self.engine.oil_pressure()
         oil_t = self.engine.oil_temperature()
         self.vertical_mode = vertical_mode
+        self.lateral_mode = lateral_mode
         return (
             alt,
             speed,
@@ -1404,6 +1409,7 @@ class Autopilot:
             ils_dist,
             self.systems.flap_operable,
             self.systems.gear_operable,
+            lateral_mode,
         )
 
 
@@ -1533,6 +1539,7 @@ class A320IFRSim:
             ils_dist,
             flap_ok,
             gear_ok,
+            _lat_mode,
         ) = self.autopilot.update()
         pitch_deg = self.fdm.get_property_value("attitude/pitch-deg")
         roll_deg = self.fdm.get_property_value("attitude/roll-deg")


### PR DESCRIPTION
## Summary
- expose autopilot lateral mode alongside vertical mode
- show lateral mode in the cockpit autopilot panel
- document the new lateral mode in cockpit docs and README

## Testing
- `python -m py_compile ifrsim.py cockpit.py a320_systems.py`
- `python a320_cockpit_example.py`

------
https://chatgpt.com/codex/tasks/task_e_687dfa140db48321b5f38d76802a11d8