### PR TITLE
Add simple navigation database

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ The primary flight display now exposes simple flight director pitch and roll
 commands from the autopilot for external indicators.
 No graphics are provided – the goal is to use external hardware like LED displays or buttons for cockpit interaction.
 
+## Navigation database
+
+The simulator now loads a simple navigation database from CSV files in
+`data/navdb`. The provided files include only a few sample airports and
+waypoints. Replace them with a full dataset (for example from the
+open-source [OurAirports](https://ourairports.com/data/) project) to fly
+real-world routes.
+
 ## Cockpit systems
 See [COCKPIT_SYSTEMS.md](COCKPIT_SYSTEMS.md) for an overview of the panels and displays modeled in the cockpit.
 

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -103,9 +103,11 @@ class FlightManagementSystem:
     """Very small FMS handling a route of waypoints."""
 
     nav: ComplexNavigationSystem
+    nav_db: "NavDatabase | None"
 
-    def __init__(self, nav: ComplexNavigationSystem) -> None:
+    def __init__(self, nav: ComplexNavigationSystem, nav_db: "NavDatabase | None" = None) -> None:
         self.nav = nav
+        self.nav_db = nav_db
 
     @property
     def waypoints(self) -> List[tuple]:
@@ -115,6 +117,18 @@ class FlightManagementSystem:
         """Load an entirely new route."""
         self.nav.waypoints = list(wpts)
         self.nav.index = 0
+
+    def load_route_by_idents(self, idents: List[str]) -> None:
+        """Load route from waypoint or airport identifiers using the nav database."""
+        if not self.nav_db:
+            raise ValueError("Navigation database not configured")
+        waypoints: List[tuple] = []
+        for ident in idents:
+            coords = self.nav_db.lookup(ident)
+            if not coords:
+                raise ValueError(f"Unknown fix identifier: {ident}")
+            waypoints.append((*coords, None))
+        self.load_route(waypoints)
 
     def add_waypoint(
         self, lat_deg: float, lon_deg: float, alt_ft: Optional[float] = None

--- a/cockpit.py
+++ b/cockpit.py
@@ -70,7 +70,7 @@ class A320Cockpit:
         self.ecam_display = EngineDisplay()
         self.pressurization = PressurizationDisplay()
         self.warnings_panel = WarningPanel()
-        self.fms = FlightManagementSystem(self.sim.nav)
+        self.fms = FlightManagementSystem(self.sim.nav, self.sim.nav_db)
         self.cockpit_systems = CockpitSystems()
 
     def set_seatbelt_sign(self, on: bool) -> None:

--- a/data/navdb/airports.csv
+++ b/data/navdb/airports.csv
@@ -1,0 +1,4 @@
+ident,name,lat_deg,lon_deg
+KJFK,John F Kennedy International,40.6413,-73.7781
+KLAX,Los Angeles International,33.9416,-118.4085
+EGLL,London Heathrow,51.4700,-0.4543

--- a/data/navdb/waypoints.csv
+++ b/data/navdb/waypoints.csv
@@ -1,0 +1,4 @@
+ident,lat_deg,lon_deg
+WPT1,40.0,-70.0
+WPT2,41.0,-71.0
+WPT3,42.0,-72.0

--- a/navdb.py
+++ b/navdb.py
@@ -1,0 +1,48 @@
+"""Simple navigation database loader."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+class NavDatabase:
+    """Load airport and waypoint data from CSV files."""
+
+    def __init__(self, airports_file: str | Path, waypoints_file: str | Path) -> None:
+        self.airports: Dict[str, Tuple[float, float]] = {}
+        self.waypoints: Dict[str, Tuple[float, float]] = {}
+        self._load_airports(airports_file)
+        self._load_waypoints(waypoints_file)
+
+    def _load_airports(self, path: str | Path) -> None:
+        with open(path, newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    lat = float(row["lat_deg"])
+                    lon = float(row["lon_deg"])
+                except (KeyError, ValueError):
+                    continue
+                self.airports[row["ident"].strip().upper()] = (lat, lon)
+
+    def _load_waypoints(self, path: str | Path) -> None:
+        with open(path, newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    lat = float(row["lat_deg"])
+                    lon = float(row["lon_deg"])
+                except (KeyError, ValueError):
+                    continue
+                self.waypoints[row["ident"].strip().upper()] = (lat, lon)
+
+    def lookup(self, ident: str) -> Tuple[float, float] | None:
+        """Return (lat, lon) for airport or waypoint identifier."""
+        ident = ident.strip().upper()
+        if ident in self.airports:
+            return self.airports[ident]
+        if ident in self.waypoints:
+            return self.waypoints[ident]
+        return None


### PR DESCRIPTION
## Summary
- add `navdb.py` with a small loader for CSV navigation data
- bundle sample `airports.csv` and `waypoints.csv`
- let `FlightManagementSystem` accept a `NavDatabase` and load routes by ident
- wire the nav database into `A320IFRSim` and `A320Cockpit`
- document the feature in the README

## Testing
- `python -m py_compile *.py`
- `python ifrsim.py` (fails without jsbsim; installed jsbsim and reran)

------
https://chatgpt.com/codex/tasks/task_e_687e08262d088321a8b5d4f6f13a7dcd