### PR TITLE
Integrate MCDU information into cockpit snapshot

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -40,6 +40,8 @@ managed by the FMS. Routes can be loaded from waypoint identifiers and the
 active waypoint can be changed or skipped. The CLI now supports `plan`, `route`
 and `direct` commands for basic flight plan editing. Waypoints can also be
 removed with `delwp INDEX` and altitude constraints set with `wpalt INDEX ALT`.
+The cockpit snapshot includes the flight plan and active waypoint index so
+external hardware can mirror the MCDU display.
 
 ## Autopilot Panel & Display
 Interfaces with the autopilot and autothrottle. The display shows current

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ The CLI now includes a few basic MCDU commands. Use `plan` to list the current
 flight plan, `route` followed by waypoint identifiers to load a new route and
 `direct` with an index to skip ahead to a specific waypoint.  Waypoints can be
 deleted with `delwp INDEX` and altitude constraints set using `wpalt INDEX ALT`
-(use `none` to clear a constraint).
+(use `none` to clear a constraint). The cockpit status snapshot now also
+includes the full flight plan and active waypoint index so external software
+can mirror the MCDU display.
 
 4. Run the cockpit system snapshot example:
 ```bash

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -530,6 +530,21 @@ class OxygenPanel:
 
 
 @dataclass
+class MCDUDisplay:
+    """Expose the flight plan and active waypoint index."""
+
+    flight_plan: List[tuple] = field(default_factory=list)
+    active_index: int = 0
+
+    def update(self, data: dict) -> None:
+        plan = data.get("flight_plan")
+        if plan is not None:
+            self.flight_plan = [tuple(wp) for wp in plan]
+        if "active_index" in data:
+            self.active_index = data["active_index"]
+
+
+@dataclass
 class CabinSignsPanel:
     """Manage seatbelt and no smoking signs."""
 
@@ -662,6 +677,7 @@ class CockpitSystems:
     parking_brake: ParkingBrakePanel = field(default_factory=ParkingBrakePanel)
     brakes: BrakesPanel = field(default_factory=BrakesPanel)
     clock: ClockPanel = field(default_factory=ClockPanel)
+    mcdu: MCDUDisplay = field(default_factory=MCDUDisplay)
 
     def update(self, data: dict) -> None:
         """Update all panels from a simulation snapshot."""
@@ -686,6 +702,7 @@ class CockpitSystems:
         self.parking_brake.update(data)
         self.brakes.update(data)
         self.clock.update(data)
+        self.mcdu.update(data.get("mcdu", {}))
         # Light states are stored in the panel itself, so no update needed
 
     def snapshot(self) -> dict:
@@ -723,5 +740,6 @@ class CockpitSystems:
             "parking_brake": asdict(self.parking_brake),
             "brakes": asdict(self.brakes),
             "clock": {"time_s": self.clock.time_s, "time_hms": self.clock.time_hms},
+            "mcdu": asdict(self.mcdu),
         }
 

--- a/cockpit.py
+++ b/cockpit.py
@@ -163,6 +163,10 @@ class A320Cockpit:
             "autopilot": autopilot_info,
             "parking_brake": self.sim.brakes.parking_brake,
             "pressure_hpa": self.altimeter.pressure_hpa,
+            "mcdu": {
+                "flight_plan": [tuple(wp) for wp in self.fms.waypoints],
+                "active_index": self.fms.nav.index,
+            },
         }
         self.cockpit_systems.update(cockpit_data)
         return {
@@ -236,6 +240,10 @@ class A320Cockpit:
             },
             "navigation": {
                 "active_waypoint": self.fms.active_waypoint(),
+            },
+            "mcdu": {
+                "flight_plan": [tuple(wp) for wp in self.fms.waypoints],
+                "active_index": self.fms.nav.index,
             },
             "fuel": {
                 "left_lbs": data["fuel_left_lbs"],


### PR DESCRIPTION
## Summary
- add new `MCDUDisplay` panel to `a320_systems`
- include flight plan data in the cockpit systems snapshot
- expose MCDU details through `A320Cockpit.step`
- document the new snapshot fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e2ba120e08321b7a0fbf5c70fbee8