### PR TITLE
Add MCDU page data to cockpit snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ flight plan, `route` followed by waypoint identifiers to load a new route and
 `direct` with an index to skip ahead to a specific waypoint.  Waypoints can be
 deleted with `delwp INDEX` and altitude constraints set using `wpalt INDEX ALT`
 (use `none` to clear a constraint). The cockpit status snapshot now also
-includes the full flight plan and active waypoint index so external software
-can mirror the MCDU display. A new `mcdu PAGE` command prints a textual
-representation of common pages like `f-plan`, `prog` and `init`.
+includes the full flight plan, the active waypoint index and the textual
+representation of all MCDU pages so external software can mirror the display.
+A new `mcdu PAGE` command prints a textual representation of common pages like
+`f-plan`, `prog` and `init`.
 
 4. Run the cockpit system snapshot example:
 ```bash

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -536,10 +536,11 @@ class OxygenPanel:
 
 @dataclass
 class MCDUDisplay:
-    """Expose the flight plan and active waypoint index."""
+    """Expose the flight plan, active waypoint and page contents."""
 
     flight_plan: List[tuple] = field(default_factory=list)
     active_index: int = 0
+    pages: dict[str, List[str]] = field(default_factory=dict)
 
     def update(self, data: dict) -> None:
         plan = data.get("flight_plan")
@@ -547,6 +548,9 @@ class MCDUDisplay:
             self.flight_plan = [tuple(wp) for wp in plan]
         if "active_index" in data:
             self.active_index = data["active_index"]
+        pages = data.get("pages")
+        if pages is not None:
+            self.pages = {name: list(lines) for name, lines in pages.items()}
 
 
 @dataclass

--- a/cockpit.py
+++ b/cockpit.py
@@ -155,6 +155,9 @@ class A320Cockpit:
             "vertical_mode": self.sim.autopilot.vertical_mode,
             "lateral_mode": self.sim.autopilot.lateral_mode,
         }
+        mcdu_pages = {
+            name: self.mcdu.get_page(name) for name in self.mcdu.list_pages()
+        }
         cockpit_data = {
             **data,
             "warnings": warnings,
@@ -166,6 +169,7 @@ class A320Cockpit:
             "mcdu": {
                 "flight_plan": [tuple(wp) for wp in self.fms.waypoints],
                 "active_index": self.fms.nav.index,
+                "pages": mcdu_pages,
             },
         }
         self.cockpit_systems.update(cockpit_data)
@@ -244,6 +248,7 @@ class A320Cockpit:
             "mcdu": {
                 "flight_plan": [tuple(wp) for wp in self.fms.waypoints],
                 "active_index": self.fms.nav.index,
+                "pages": mcdu_pages,
             },
             "fuel": {
                 "left_lbs": data["fuel_left_lbs"],


### PR DESCRIPTION
## Summary
- extend `MCDUDisplay` to store page contents
- include MCDU pages in cockpit step output
- document snapshot update in README

## Testing
- `python -m py_compile mcdu.py cockpit.py a320_systems.py complex_navigation.py`
- `python a320_cockpit_example.py | head -n 20` *(fails: ModuleNotFoundError: No module named 'jsbsim')*
- `pip install jsbsim --quiet`
- `python a320_cockpit_example.py | head -n 20`
- `python - <<'PY'
from cockpit import A320Cockpit
cp=A320Cockpit()
status=cp.step()
print('mcdu pages keys', list(status['mcdu']['pages'].keys()))
PY
`
- `python - <<'PY'
from cockpit import A320Cockpit
cp=A320Cockpit()
cp.step()
snap=cp.cockpit_systems.snapshot()
print('mcdu pages', snap['mcdu']['pages'].keys())
PY
`

------
https://chatgpt.com/codex/tasks/task_e_687e341438708321abb078c96dc6533c