### PR TITLE
Add index page to MCDU and page listing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ deleted with `delwp INDEX` and altitude constraints set using `wpalt INDEX ALT`
 (use `none` to clear a constraint). The cockpit status snapshot now also
 includes the full flight plan, the active waypoint index and the textual
 representation of all MCDU pages so external software can mirror the display.
-A new `mcdu PAGE` command prints a textual representation of common pages like
-`f-plan`, `prog` and `init`.
+A new `mcdu pages` command lists all available pages and `mcdu PAGE` prints the
+textual representation of a selected page. The built-in pages include an index
+(`idx`) plus `f-plan`, `prog` and `init`.
 
 4. Run the cockpit system snapshot example:
 ```bash

--- a/cockpit.py
+++ b/cockpit.py
@@ -155,9 +155,7 @@ class A320Cockpit:
             "vertical_mode": self.sim.autopilot.vertical_mode,
             "lateral_mode": self.sim.autopilot.lateral_mode,
         }
-        mcdu_pages = {
-            name: self.mcdu.get_page(name) for name in self.mcdu.list_pages()
-        }
+        mcdu_pages = self.mcdu.all_pages()
         cockpit_data = {
             **data,
             "warnings": warnings,

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -34,6 +34,7 @@ HELP_TEXT = """Available commands:
   direct INDEX        - skip to flight plan waypoint
   delwp INDEX         - delete waypoint at INDEX
   wpalt INDEX ALT     - set altitude constraint for waypoint
+  mcdu pages          - list available MCDU pages
   mcdu PAGE           - show a textual MCDU page
   quit                - exit the program"""
 
@@ -302,7 +303,12 @@ def main() -> None:
                 print(f"Error: {exc}")
             continue
         if cmd == "mcdu" and args:
-            page = args[0]
+            sub = args[0]
+            if sub == "pages":
+                for name in cp.mcdu.list_pages():
+                    print(name)
+                continue
+            page = sub
             try:
                 lines = cp.mcdu.get_page(page)
             except Exception as exc:

--- a/mcdu.py
+++ b/mcdu.py
@@ -12,7 +12,7 @@ class MCDU:
 
     def __init__(self, fms: FlightManagementSystem) -> None:
         self.fms = fms
-        self.pages = ["f-plan", "prog", "init"]
+        self.pages = ["idx", "f-plan", "prog", "init"]
 
     def load_route(self, idents: List[str]) -> None:
         """Load a new flight plan by waypoint identifiers."""
@@ -57,11 +57,20 @@ class MCDU:
         """Return available MCDU pages."""
         return list(self.pages)
 
+    def all_pages(self) -> dict[str, List[str]]:
+        """Return a mapping of page names to their textual representation."""
+        return {name: self.get_page(name) for name in self.pages}
+
     def get_page(self, name: str) -> List[str]:
         """Return a simple textual representation of an MCDU page."""
         lname = name.lower()
         if lname not in self.pages:
             raise ValueError(f"Unknown page: {name}")
+        if lname == "idx":
+            lines = ["INDEX"]
+            for p in self.pages:
+                lines.append(p.upper())
+            return lines
         if lname == "f-plan":
             lines = ["F-PLAN"]
             for i, wp in enumerate(self.fms.waypoints):


### PR DESCRIPTION
## Summary
- add an `idx` page to the MCDU
- expose `MCDU.all_pages()` and use it in `A320Cockpit`
- show new command `mcdu pages` in the CLI and update README

## Testing
- `python -m py_compile mcdu.py cockpit.py cockpit_cli.py`
- `python cockpit_cli.py <<EOF
help
mcdu pages
mcdu idx
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687e36e449c88321961d02dce5d06edc