### PR TITLE
Add ECAM pages integration

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -17,7 +17,9 @@ can mimic the real Airbus layout.
 Reports N1 thrust levels, oil pressure and temperature, exhaust gas
 temperature, remaining fuel and APU bleed flow. It also shows the number of
 available fire bottles.  Each engine is tracked individually and a simplified
-fuel flow indicator helps monitor consumption and diagnose failures.
+fuel flow indicator helps monitor consumption and diagnose failures. The ECAM
+provides several textual pages such as `ENG`, `FUEL` and `ELEC` which can be
+listed and displayed through the CLI.
 
 ## Pressurization Display
 Shows cabin altitude, differential pressure and temperature.  The display is

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ representation of all MCDU pages so external software can mirror the display.
 A new `mcdu pages` command lists all available pages and `mcdu PAGE` prints the
 textual representation of a selected page. The built-in pages include an index
 (`idx`) plus `f-plan`, `prog` and `init`.
+The ECAM has received similar treatment. The cockpit snapshot now contains a
+textual representation of all ECAM pages. Use `ecam pages` to list them and
+`ecam PAGE` to view a specific page like `eng` or `fuel`.
 
 4. Run the cockpit system snapshot example:
 ```bash

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -554,6 +554,18 @@ class MCDUDisplay:
 
 
 @dataclass
+class ECAMPageDisplay:
+    """Store textual ECAM page data."""
+
+    pages: dict[str, List[str]] = field(default_factory=dict)
+
+    def update(self, data: dict) -> None:
+        pages = data.get("ecam_pages")
+        if pages is not None:
+            self.pages = {name: list(lines) for name, lines in pages.items()}
+
+
+@dataclass
 class CabinSignsPanel:
     """Manage seatbelt and no smoking signs."""
 
@@ -687,6 +699,7 @@ class CockpitSystems:
     brakes: BrakesPanel = field(default_factory=BrakesPanel)
     clock: ClockPanel = field(default_factory=ClockPanel)
     mcdu: MCDUDisplay = field(default_factory=MCDUDisplay)
+    ecam_pages: ECAMPageDisplay = field(default_factory=ECAMPageDisplay)
 
     def update(self, data: dict) -> None:
         """Update all panels from a simulation snapshot."""
@@ -712,6 +725,7 @@ class CockpitSystems:
         self.brakes.update(data)
         self.clock.update(data)
         self.mcdu.update(data.get("mcdu", {}))
+        self.ecam_pages.update(data)
         # Light states are stored in the panel itself, so no update needed
 
     def snapshot(self) -> dict:
@@ -750,5 +764,6 @@ class CockpitSystems:
             "brakes": asdict(self.brakes),
             "clock": {"time_s": self.clock.time_s, "time_hms": self.clock.time_hms},
             "mcdu": asdict(self.mcdu),
+            "ecam_pages": self.ecam_pages.pages,
         }
 

--- a/cockpit.py
+++ b/cockpit.py
@@ -36,6 +36,7 @@ from a320_systems import (
     CockpitSystems,
 )
 from mcdu import MCDU
+from ecam import ECAM
 
 
 class A320Cockpit:
@@ -74,6 +75,7 @@ class A320Cockpit:
         self.fms = FlightManagementSystem(self.sim.nav, self.sim.nav_db)
         self.mcdu = MCDU(self.fms)
         self.cockpit_systems = CockpitSystems()
+        self.ecam = ECAM(self.cockpit_systems)
 
     def set_seatbelt_sign(self, on: bool) -> None:
         """Toggle the seatbelt sign."""
@@ -156,6 +158,7 @@ class A320Cockpit:
             "lateral_mode": self.sim.autopilot.lateral_mode,
         }
         mcdu_pages = self.mcdu.all_pages()
+        ecam_pages = self.ecam.all_pages()
         cockpit_data = {
             **data,
             "warnings": warnings,
@@ -169,6 +172,7 @@ class A320Cockpit:
                 "active_index": self.fms.nav.index,
                 "pages": mcdu_pages,
             },
+            "ecam_pages": ecam_pages,
         }
         self.cockpit_systems.update(cockpit_data)
         return {
@@ -188,6 +192,7 @@ class A320Cockpit:
                 "fuel_lbs": self.ecam_display.fuel_lbs,
                 "apu_flow_pph": self.ecam_display.apu_flow_pph,
                 "fire_bottles": self.ecam_display.fire_bottles,
+                "pages": ecam_pages,
             },
             "radio": {
                 "com1_active": self.radio.com1_active,

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -36,6 +36,8 @@ HELP_TEXT = """Available commands:
   wpalt INDEX ALT     - set altitude constraint for waypoint
   mcdu pages          - list available MCDU pages
   mcdu PAGE           - show a textual MCDU page
+  ecam pages          - list available ECAM pages
+  ecam PAGE           - show a textual ECAM page
   quit                - exit the program"""
 
 
@@ -311,6 +313,21 @@ def main() -> None:
             page = sub
             try:
                 lines = cp.mcdu.get_page(page)
+            except Exception as exc:
+                print(f"Error: {exc}")
+            else:
+                for line in lines:
+                    print(line)
+            continue
+        if cmd == "ecam" and args:
+            sub = args[0]
+            if sub == "pages":
+                for name in cp.ecam.list_pages():
+                    print(name)
+                continue
+            page = sub
+            try:
+                lines = cp.ecam.get_page(page)
             except Exception as exc:
                 print(f"Error: {exc}")
             else:

--- a/ecam.py
+++ b/ecam.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict
+
+from a320_systems import CockpitSystems
+
+
+@dataclass
+class ECAM:
+    """Generate simple textual ECAM pages from cockpit system data."""
+
+    systems: CockpitSystems
+    pages: List[str]
+
+    def __init__(self, systems: CockpitSystems) -> None:
+        self.systems = systems
+        self.pages = [
+            "idx",
+            "eng",
+            "bleed",
+            "hyd",
+            "elec",
+            "fuel",
+            "status",
+        ]
+
+    def list_pages(self) -> List[str]:
+        return list(self.pages)
+
+    def all_pages(self) -> Dict[str, List[str]]:
+        return {name: self.get_page(name) for name in self.pages}
+
+    def get_page(self, name: str) -> List[str]:
+        lname = name.lower()
+        if lname not in self.pages:
+            raise ValueError(f"Unknown page: {name}")
+        if lname == "idx":
+            lines = ["INDEX"]
+            for p in self.pages:
+                lines.append(p.upper())
+            return lines
+        if lname == "eng":
+            e = self.systems.engine
+            lines = ["ENG"]
+            for i, n1 in enumerate(e.n1, 1):
+                egt = e.egt[i - 1] if i - 1 < len(e.egt) else 0.0
+                lines.append(f"ENG{i} N1 {n1:.0f}% EGT {egt:.0f}")
+            lines.append(f"OIL {e.oil_press:.0f}psi {e.oil_temp:.0f}C")
+            lines.append(
+                f"FUEL {e.fuel_lbs:.0f}LB APU {e.apu_flow_pph:.0f}PPH"
+            )
+            return lines
+        if lname == "bleed":
+            b = self.systems.bleed_air
+            p = self.systems.pressurization
+            lines = ["BLEED"]
+            lines.append(f"PRES {b.pressure:.0f}psi")
+            lines.append(f"A-ICE {'ON' if b.anti_ice_on else 'OFF'}")
+            lines.append(f"WING {'ON' if b.wing_anti_ice_on else 'OFF'}")
+            lines.append(f"CAB ALT {p.cabin_alt_ft:.0f}FT")
+            lines.append(f"CAB DIFF {p.diff_psi:.1f} PSI")
+            return lines
+        if lname == "hyd":
+            h = self.systems.hydraulics
+            return ["HYD", f"PRES {h.pressure:.0f}psi"]
+        if lname == "elec":
+            e = self.systems.electrical
+            lines = ["ELEC"]
+            lines.append(f"CHARGE {e.charge:.0f}%")
+            lines.append(f"APU {'ON' if e.apu_running else 'OFF'}")
+            lines.append(f"GEN FAIL {'YES' if e.generator_failed else 'NO'}")
+            lines.append(f"RAT {'DEPLOYED' if e.rat_deployed else 'STOWED'}")
+            return lines
+        if lname == "fuel":
+            f = self.systems.fuel
+            lines = ["FUEL"]
+            lines.append(f"L {f.left_lbs:.0f} R {f.right_lbs:.0f}")
+            lines.append(f"TOTAL {f.total_lbs:.0f}LB")
+            lines.append(f"XFEED {'ON' if f.crossfeed else 'OFF'}")
+            return lines
+        if lname == "status":
+            w = self.systems.warnings
+            lines = ["STATUS"]
+            if w.fire:
+                lines.append("ENG FIRE")
+            if w.stall:
+                lines.append("STALL")
+            if w.gpws:
+                lines.append("TERRAIN")
+            if w.overspeed:
+                lines.append("OVERSPEED")
+            if w.tcas:
+                lines.append("TCAS")
+            if len(lines) == 1:
+                lines.append("NORMAL")
+            return lines
+        return []


### PR DESCRIPTION
## Summary
- add `ECAM` helper for textual ECAM pages
- track ECAM pages in `CockpitSystems`
- expose ECAM pages from `A320Cockpit`
- support `ecam` commands in the CLI
- document ECAM pages in README and cockpit systems doc

## Testing
- `python -m py_compile ecam.py a320_systems.py cockpit.py cockpit_cli.py mcdu.py`
- `find . -name '*.py' | xargs python -m py_compile`
- `python - <<'PY'
from cockpit import A320Cockpit
cp = A320Cockpit()
print('pages', cp.ecam.list_pages())
status = cp.step()
print('ecam pages keys', status['ecam']['pages'].keys())
PY`

------
https://chatgpt.com/codex/tasks/task_e_687e3875707883218c4304f40d78febc