### PR TITLE
Add OverheadPanel controls

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -110,7 +110,8 @@ of the major systems can be assessed at a glance.
 
 ## Overhead Panel
 Indicates APU running state and fuel crossfeed status similar to the annunciator
-lights on a real overhead panel.
+lights on a real overhead panel. The panel can also start or stop the APU and
+toggle fuel crossfeed just like the separate APU and fuel controls.
 
 ## Hydraulic Panel
 Shows the current hydraulic system pressure.  Loss of pressure reduces control

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ the cockpit interface.
 A simple navigation display shows distance to the active waypoint and ILS
 deviations, while a small systems page tracks hydraulic, electrical and
 bleed air pressure. An overhead panel monitors the APU and fuel crossfeed
-A new electrical panel reports generator failures and RAT deployment so
-power issues are easier to diagnose. An overhead panel monitors the APU and
-fuel crossfeed state.
+state and can be used to start or stop the APU or toggle crossfeed. A new
+electrical panel reports generator failures and RAT deployment so power
+issues are easier to diagnose.
 A simple TCAS display now reports the bearing, distance and altitude
 difference to any conflicting traffic.
 A new bleed air model now ties engine and APU performance to cabin

--- a/cockpit.py
+++ b/cockpit.py
@@ -57,7 +57,7 @@ class A320Cockpit:
         self.nav_display = NavigationDisplay()
         self.tcas_display = TCASDisplay()
         self.system_status = SystemsStatusPanel()
-        self.overhead = OverheadPanel()
+        self.overhead = OverheadPanel(self.sim.electrics, self.sim.fuel)
         self.hydraulic_panel = HydraulicPanel()
         self.bleed_air_panel = BleedAirPanel()
         self.environment_panel = EnvironmentPanel()
@@ -74,7 +74,7 @@ class A320Cockpit:
         self.warnings_panel = WarningPanel()
         self.fms = FlightManagementSystem(self.sim.nav, self.sim.nav_db)
         self.mcdu = MCDU(self.fms)
-        self.cockpit_systems = CockpitSystems()
+        self.cockpit_systems = CockpitSystems(overhead=self.overhead)
         self.ecam = ECAM(self.cockpit_systems)
 
     def set_seatbelt_sign(self, on: bool) -> None:

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -180,9 +180,9 @@ def main() -> None:
             continue
         if cmd == "xfeed" and args:
             if args[0] == "on":
-                cp.fuel.enable_crossfeed()
+                cp.overhead.enable_crossfeed()
             elif args[0] == "off":
-                cp.fuel.disable_crossfeed()
+                cp.overhead.disable_crossfeed()
             else:
                 print("Usage: xfeed on|off")
             continue
@@ -336,9 +336,9 @@ def main() -> None:
             continue
         if cmd == "apu" and args:
             if args[0] == "start":
-                cp.apu.start()
+                cp.overhead.start_apu()
             elif args[0] == "stop":
-                cp.apu.stop()
+                cp.overhead.stop_apu()
             else:
                 print("Usage: apu start|stop")
             continue


### PR DESCRIPTION
## Summary
- allow controlling APU and crossfeed via OverheadPanel
- pass electric and fuel systems to OverheadPanel
- expose new overhead functions in the CLI
- document overhead panel capabilities

## Testing
- `python -m py_compile a320_systems.py cockpit.py cockpit_cli.py`
- `python a320_cockpit_example.py 1`

------
https://chatgpt.com/codex/tasks/task_e_687e4b20ca908321b2d93b22aa989803