### PR TITLE
Integrate engine warning display

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -31,6 +31,11 @@ Aggregates master caution, stall, ground proximity, overspeed, fire and TCAS
 warnings.  When multiple warnings are active the highest priority alert can be
 driven to external annunciators.
 
+## Engine Warning/System Display
+Combines key engine parameters with the active warning flags so a dedicated
+E/WD can be driven from the snapshot data. The display mirrors the engine
+N1, EGT, oil pressure and fuel figures alongside the master caution states.
+
 ## Flight Management System (FMS)
 A small wrapper around the navigation system that stores waypoints and allows
 basic route management.  Waypoints may include altitude constraints which the

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ An exhaust temperature model now tracks engine heat and can cause
 failures when limits are exceeded for even more realism.
 A simple master caution system now highlights active warnings from
 multiple subsystems.
+A compact engine warning/system display mirrors the current N1, EGT and oil
+readings alongside any active cautions.
 A simple vertical navigation mode adjusts climb and descent rates to
 meet waypoint altitude constraints when following a route.
 An approach mode now tracks an ILS localizer and glideslope for hands-off
@@ -149,6 +151,9 @@ textual representation of a selected page. The built-in pages include an index
 The ECAM has received similar treatment. The cockpit snapshot now contains a
 textual representation of all ECAM pages. Use `ecam pages` to list them and
 `ecam PAGE` to view a specific page like `eng` or `fuel`.
+The snapshot also exposes a combined Engine Warning/System display under the
+`ewd` key which mirrors engine data and active cautions.
+Use the `ewd` command in the CLI to print this summary.
 
 4. Run the cockpit system snapshot example:
 ```bash

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -53,6 +53,28 @@ class EngineDisplay:
 
 
 @dataclass
+class EngineWarningDisplay:
+    """Summarize engine parameters and active warnings."""
+
+    n1: List[float] = field(default_factory=list)
+    egt: List[float] = field(default_factory=list)
+    oil_press: float = 0.0
+    oil_temp: float = 0.0
+    fuel_lbs: float = 0.0
+    warnings: dict[str, bool] = field(default_factory=dict)
+
+    def update(self, data: dict) -> None:
+        self.n1 = data.get("n1", [])
+        self.egt = data.get("egt", [])
+        self.oil_press = data.get("oil_press", 0.0)
+        self.oil_temp = data.get("oil_temp", 0.0)
+        self.fuel_lbs = data.get("fuel_lbs", 0.0)
+        warnings = data.get("warnings")
+        if warnings is not None:
+            self.warnings = dict(warnings)
+
+
+@dataclass
 class PressurizationDisplay:
     """Show basic cabin pressurization information."""
 
@@ -712,6 +734,7 @@ class CockpitSystems:
 
     pfd: PrimaryFlightDisplay = field(default_factory=PrimaryFlightDisplay)
     engine: EngineDisplay = field(default_factory=EngineDisplay)
+    ewd: EngineWarningDisplay = field(default_factory=EngineWarningDisplay)
     pressurization: PressurizationDisplay = field(default_factory=PressurizationDisplay)
     warnings: WarningPanel = field(default_factory=WarningPanel)
     navigation: NavigationDisplay = field(default_factory=NavigationDisplay)
@@ -741,6 +764,7 @@ class CockpitSystems:
         """Update all panels from a simulation snapshot."""
         self.pfd.update(data)
         self.engine.update(data)
+        self.ewd.update(data)
         self.pressurization.update(data)
         self.warnings.update({"warnings": data.get("warnings", {})})
         self.navigation.update(data)
@@ -769,6 +793,7 @@ class CockpitSystems:
         return {
             "pfd": asdict(self.pfd),
             "engine": asdict(self.engine),
+            "ewd": asdict(self.ewd),
             "pressurization": asdict(self.pressurization),
             "warnings": asdict(self.warnings),
             "navigation": asdict(self.navigation),

--- a/cockpit.py
+++ b/cockpit.py
@@ -214,6 +214,14 @@ class A320Cockpit:
                 "fire_bottles": self.ecam_display.fire_bottles,
                 "pages": ecam_pages,
             },
+            "ewd": {
+                "n1": self.ecam_display.n1,
+                "egt": self.ecam_display.egt,
+                "oil_press": self.ecam_display.oil_press,
+                "oil_temp": self.ecam_display.oil_temp,
+                "fuel_lbs": self.ecam_display.fuel_lbs,
+                "warnings": warnings,
+            },
             "radio": {
                 "com1_active": self.radio.com1_active,
                 "com1_standby": self.radio.com1_standby,

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -38,6 +38,7 @@ HELP_TEXT = """Available commands:
   mcdu PAGE           - show a textual MCDU page
   ecam pages          - list available ECAM pages
   ecam PAGE           - show a textual ECAM page
+  ewd                 - show the engine warning/system display
   quit                - exit the program"""
 
 
@@ -333,6 +334,20 @@ def main() -> None:
             else:
                 for line in lines:
                     print(line)
+            continue
+        if cmd == "ewd":
+            snapshot = cp.cockpit_systems.snapshot()
+            ewd = snapshot.get("ewd", {})
+            n1 = "/".join(f"{n:.0f}" for n in ewd.get("n1", []))
+            egt = "/".join(f"{e:.0f}" for e in ewd.get("egt", []))
+            line = (
+                f"N1 {n1} EGT {egt} OIL {ewd.get('oil_press', 0):.0f}psi "
+                f"FUEL {ewd.get('fuel_lbs', 0):.0f}LB"
+            )
+            active = [name.upper() for name, on in ewd.get("warnings", {}).items() if on]
+            if active:
+                line += " WARN " + " ".join(active)
+            print(line)
             continue
         if cmd == "apu" and args:
             if args[0] == "start":


### PR DESCRIPTION
## Summary
- aggregate engine parameters and warnings in a new `EngineWarningDisplay`
- expose `ewd` snapshot data via `CockpitSystems` and `A320Cockpit`
- add an `ewd` command to the CLI
- document the engine warning/system display in the README and systems guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python a320_cockpit_example.py 1` *(fails: ModuleNotFoundError: No module named 'jsbsim')*

------
https://chatgpt.com/codex/tasks/task_e_687e5503a73c832186b111c6f9f8c36f