### PR TITLE
Integrate engine warning display

### DIFF
--- a/a320_cockpit_example.py
+++ b/a320_cockpit_example.py
@@ -9,13 +9,16 @@ def main(steps: int = 10) -> None:
         snapshot = cp.cockpit_systems.snapshot()
         # Print a couple of key values from different panels
         pfd = snapshot["pfd"]
-        engine = snapshot["engine"]
+        ewd = snapshot["ewd"]
         warnings = snapshot["warnings"]
+        active = [name.upper() for name, on in ewd.get("warnings", {}).items() if on]
+        warn_text = " WARN " + " ".join(active) if active else ""
         print(
             f"ALT {pfd['altitude_ft']:.0f}FT SPD {pfd['speed_kt']:.1f}KT "
             f"HDG {pfd['heading_deg']:.0f} VS {pfd['vs_fpm']:.0f}FPM "
-            f"N1 {engine['n1'][0]:.2f}/{engine['n1'][1]:.2f} "
-            f"MC {'ON' if warnings['master_caution'] else 'OFF'}"
+            f"N1 {ewd['n1'][0]:.2f}/{ewd['n1'][1]:.2f} "
+            f"EGT {ewd['egt'][0]:.0f}/{ewd['egt'][1]:.0f} "
+            f"MC {'ON' if warnings['master_caution'] else 'OFF'}" + warn_text
         )
 
 

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -45,6 +45,7 @@ HELP_TEXT = """Available commands:
 def print_status(status: dict) -> None:
     pfd = status["pfd"]
     ecam = status["ecam"]
+    ewd = status.get("ewd", {})
     line = (
         f"ALT {pfd['altitude_ft']:.0f}FT "
         f"SPD {pfd['speed_kt']:.1f}KT "
@@ -67,6 +68,9 @@ def print_status(status: dict) -> None:
             f" {tcas['distance_nm']:.1f}NM"
             f" {tcas['alt_diff_ft']:.0f}FT"
         )
+    active = [name.upper() for name, on in ewd.get("warnings", {}).items() if on]
+    if active:
+        line += " WARN " + " ".join(active)
     print(line)
 
 


### PR DESCRIPTION
## Summary
- surface active warnings in `print_status`
- show warnings in the cockpit example

## Testing
- `python -m py_compile a320_cockpit_example.py cockpit_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_687e580b79e88321bdd551b1f1e42b10