### PR TITLE
Integrate radio management panel

### DIFF
--- a/COCKPIT_SYSTEMS.md
+++ b/COCKPIT_SYSTEMS.md
@@ -61,6 +61,9 @@ can mimic the Airbus flight mode annunciations.
 ## Radio Panel
 Provides simple COM1/COM2 frequency management.  Active and standby
 frequencies can be swapped to simulate standard Airbus radio operation.
+The CLI offers `com1` and `com2` commands to tune the standby
+frequencies, `swap1` and `swap2` to activate them and a `radio` command to
+print the current settings.
 
 ## Transponder
 Allows setting of the transponder code and operating mode.  Selecting

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ textual representation of all ECAM pages. Use `ecam pages` to list them and
 The snapshot also exposes a combined Engine Warning/System display under the
 `ewd` key which mirrors engine data and active cautions.
 Use the `ewd` command in the CLI to print this summary.
+The radio management panel is now integrated as well. Use `com1 FREQ` or
+`com2 FREQ` to tune the standby frequencies, `swap1` or `swap2` to activate
+them and `radio` to print the current settings.
 
 4. Run the cockpit system snapshot example:
 ```bash

--- a/a320_systems.py
+++ b/a320_systems.py
@@ -257,6 +257,14 @@ class RadioPanel:
         self.com2_active = 119.0
         self.com2_standby = 122.5
 
+    def set_com1(self, freq: float) -> None:
+        """Tune the COM1 standby frequency."""
+        self.com1_standby = float(freq)
+
+    def set_com2(self, freq: float) -> None:
+        """Tune the COM2 standby frequency."""
+        self.com2_standby = float(freq)
+
     def swap_com1(self) -> None:
         self.com1_active, self.com1_standby = (
             self.com1_standby,
@@ -268,6 +276,26 @@ class RadioPanel:
             self.com2_standby,
             self.com2_active,
         )
+
+
+@dataclass
+class RadioDisplay:
+    """Display COM1 and COM2 frequencies."""
+
+    com1_active: float = 0.0
+    com1_standby: float = 0.0
+    com2_active: float = 0.0
+    com2_standby: float = 0.0
+
+    def update(self, data: dict) -> None:
+        if "com1_active" in data:
+            self.com1_active = data["com1_active"]
+        if "com1_standby" in data:
+            self.com1_standby = data["com1_standby"]
+        if "com2_active" in data:
+            self.com2_active = data["com2_active"]
+        if "com2_standby" in data:
+            self.com2_standby = data["com2_standby"]
 
 
 class Transponder:
@@ -741,6 +769,7 @@ class CockpitSystems:
     tcas: TCASDisplay = field(default_factory=TCASDisplay)
     autopilot: AutopilotDisplay = field(default_factory=AutopilotDisplay)
     radio: RadioPanel = field(default_factory=RadioPanel)
+    radio_display: RadioDisplay = field(default_factory=RadioDisplay)
     transponder: Transponder = field(default_factory=Transponder)
     systems: SystemsStatusPanel = field(default_factory=SystemsStatusPanel)
     overhead: OverheadPanel = field(default_factory=OverheadPanel)
@@ -770,6 +799,12 @@ class CockpitSystems:
         self.navigation.update(data)
         self.tcas.update(data)
         self.autopilot.update(data.get("autopilot", {}))
+        self.radio_display.update(data.get("radio", {
+            "com1_active": self.radio.com1_active,
+            "com1_standby": self.radio.com1_standby,
+            "com2_active": self.radio.com2_active,
+            "com2_standby": self.radio.com2_standby,
+        }))
         self.systems.update(data)
         self.hydraulics.update(data)
         self.electrical.update(data)
@@ -799,12 +834,7 @@ class CockpitSystems:
             "navigation": asdict(self.navigation),
             "tcas": asdict(self.tcas),
             "autopilot": asdict(self.autopilot),
-            "radio": {
-                "com1_active": self.radio.com1_active,
-                "com1_standby": self.radio.com1_standby,
-                "com2_active": self.radio.com2_active,
-                "com2_standby": self.radio.com2_standby,
-            },
+            "radio": asdict(self.radio_display),
             "transponder": {
                 "code": self.transponder.code,
                 "mode": self.transponder.mode,

--- a/cockpit.py
+++ b/cockpit.py
@@ -183,6 +183,12 @@ class A320Cockpit:
             "apu_running": self.sim.electrics.apu_running,
             "generator_failed": self.sim.electrics.generator_failed,
             "autopilot": autopilot_info,
+            "radio": {
+                "com1_active": self.radio.com1_active,
+                "com1_standby": self.radio.com1_standby,
+                "com2_active": self.radio.com2_active,
+                "com2_standby": self.radio.com2_standby,
+            },
             "parking_brake": self.sim.brakes.parking_brake,
             "pressure_hpa": self.altimeter.pressure_hpa,
             "mcdu": {

--- a/cockpit_cli.py
+++ b/cockpit_cli.py
@@ -40,6 +40,11 @@ HELP_TEXT = """Available commands:
   ecam PAGE           - show a textual ECAM page
   ewd                 - show the engine warning/system display
   nd                  - show the navigation display
+  radio               - show current radio frequencies
+  com1 FREQ           - tune COM1 standby frequency
+  com2 FREQ           - tune COM2 standby frequency
+  swap1               - swap COM1 active and standby
+  swap2               - swap COM2 active and standby
   quit                - exit the program"""
 
 
@@ -89,6 +94,17 @@ def print_nav_display(status: dict) -> None:
         f"D2ILS {(nd.get('ils_distance_nm') or 0.0):.1f}NM "
         f"LOC {(nd.get('loc_dev_deg') or 0.0):.1f}deg "
         f"GS {(nd.get('gs_dev_ft') or 0.0):.0f}FT"
+    )
+    print(line)
+
+
+def print_radio(status: dict) -> None:
+    radio = status.get("radio", {})
+    line = (
+        f"COM1 {radio.get('com1_active', 0.0):.3f}/"
+        f"{radio.get('com1_standby', 0.0):.3f} "
+        f"COM2 {radio.get('com2_active', 0.0):.3f}/"
+        f"{radio.get('com2_standby', 0.0):.3f}"
     )
     print(line)
 
@@ -375,6 +391,28 @@ def main() -> None:
         if cmd == "nd":
             snapshot = cp.cockpit_systems.snapshot()
             print_nav_display(snapshot)
+            continue
+        if cmd == "radio":
+            snapshot = cp.cockpit_systems.snapshot()
+            print_radio(snapshot)
+            continue
+        if cmd == "com1" and args:
+            try:
+                cp.radio.set_com1(float(args[0]))
+            except ValueError:
+                print("Invalid frequency")
+            continue
+        if cmd == "com2" and args:
+            try:
+                cp.radio.set_com2(float(args[0]))
+            except ValueError:
+                print("Invalid frequency")
+            continue
+        if cmd == "swap1":
+            cp.radio.swap_com1()
+            continue
+        if cmd == "swap2":
+            cp.radio.swap_com2()
             continue
         if cmd == "apu" and args:
             if args[0] == "start":


### PR DESCRIPTION
## Summary
- expand `RadioPanel` with tuning methods
- add `RadioDisplay` dataclass and expose it through `CockpitSystems`
- update cockpit step to supply radio data
- implement radio commands in CLI
- document the radio panel in README and COCKPIT_SYSTEMS

## Testing
- `python -m py_compile a320_systems.py cockpit.py cockpit_cli.py a320_cockpit_example.py ifrsim.py navdb.py mcdu.py ecam.py tcas.py complex_navigation.py`

------
https://chatgpt.com/codex/tasks/task_e_687f3692088c8321a24ba0464c28653e